### PR TITLE
Add hidden code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,20 @@ Some Markdown parsers support two or three dashes around comments, this module
 supports both variants. The `case` parameter is optional and might be used for
 subtests, see "Code split" section.
 
+Additionally, a code block can be put inside the comment block to hide some 
+initialization from the readers.
+
+````markdown
+<!-- name: test_name
+```python
+init_some_variable = 123
+```
+-->
+```python
+assert init_some_variable == 123
+```
+````
+
 Common parsing rules
 --------------------
 

--- a/tests.md
+++ b/tests.md
@@ -18,6 +18,16 @@ name: test_multiline_comment_2
 assert True
 ```
 
+<!--
+name: test_multiline_hidden_code_block
+```python
+hidden_value = 123
+```
+-->
+```python
+assert hidden_value == 123
+```
+
 <!-- name: test_with_subtests -->
 ```python
 from collections import Counter


### PR DESCRIPTION
**What:** Supporting hidden code blocks (inside the comments)

**Why:** Sometimes you may want to provide an example with a dependency, which you would like to initialize or mock stealthily rather than complicating the readme.
 
**Usage:**
````
<!--
name: test_multiline_hidden_code_block
```python
hidden_value = 123
```
-->
```python
assert hidden_value == 123
```
````