### PR TITLE
add subprocess tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,84 @@ assert rows[1] == {"name": "Bob", "role": "viewer"}
 ```
 -->
 
+Subprocess mode
+---------------
+
+Add `subprocess: true` to run a test in its own Python subprocess instead
+of the main pytest process. This is useful when the code under test
+modifies global state, calls `os.exit()`, or needs full process isolation.
+
+``````
+<!-- name: test_isolated; subprocess: true -->
+```python
+import sys
+sys.modules["__demo_marker__"] = True
+assert "__demo_marker__" in sys.modules
+```
+``````
+
+<!-- name: test_isolated; subprocess: true -->
+```python
+import sys
+sys.modules["__demo_marker__"] = True
+assert "__demo_marker__" in sys.modules
+```
+
+Subprocess tests support split blocks — multiple blocks with the same name
+are combined before being executed in a single subprocess:
+
+``````
+<!-- name: test_sub_split; subprocess: true -->
+```python
+data = {"key": "value"}
+```
+
+<!-- name: test_sub_split; subprocess: true -->
+```python
+assert data["key"] == "value"
+```
+``````
+
+<!-- name: test_sub_split; subprocess: true -->
+```python
+data = {"key": "value"}
+```
+
+<!-- name: test_sub_split; subprocess: true -->
+```python
+assert data["key"] == "value"
+```
+
+Hidden blocks also work with subprocess mode:
+
+``````
+<!--
+name: test_sub_hidden;
+subprocess: true
+```python
+_setup_value = 99
+```
+-->
+```python
+assert _setup_value == 99
+```
+``````
+
+<!--
+name: test_sub_hidden;
+subprocess: true
+```python
+_setup_value = 99
+```
+-->
+```python
+assert _setup_value == 99
+```
+
+> **Note:** subprocess tests cannot use pytest fixtures or subtests — those
+> features require the in-process test runner. If a test needs fixtures,
+> omit `subprocess: true`.
+
 Comment syntax
 --------------
 
@@ -481,6 +559,8 @@ Available comment parameters:
 * `case` — marks the block as a subtest (see [Subtests](#subtests)).
 * `fixtures` — comma-separated list of pytest fixtures to inject
   (see [Fixtures](#fixtures)).
+* `subprocess` — set to `true` to run the test in a separate Python
+  process (see [Subprocess mode](#subprocess-mode)).
 
 Fixture lists can be written in several ways:
 
@@ -590,3 +670,6 @@ Sample output:
     README.md::test_counter PASSED
     README.md::test_with_tmp_path PASSED
     README.md::test_hidden_demo PASSED
+    README.md::test_isolated PASSED
+    README.md::test_sub_split PASSED
+    README.md::test_sub_hidden PASSED


### PR DESCRIPTION
This pull request introduces support for running Markdown-based tests in isolated Python subprocesses, enhancing test reliability and isolation. It adds the `subprocess: true` parameter for test blocks, updates documentation, and implements the subprocess execution logic. Comprehensive tests are included to verify the new functionality and edge cases.

**Subprocess test execution support:**

* Added the `subprocess: true` parameter to Markdown test block comments, allowing tests to run in a separate Python process for full isolation. This is useful for tests that modify global state, call `os.exit()`, or require process-level isolation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R454-R531) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R562-R563)
* Implemented the `subprocess_caller` static method in the `MDModule` class to execute test code in a subprocess, handling temporary file creation, process execution, and error reporting.
* Updated the `collect` method in `MDModule` to detect and group blocks with `subprocess: true`, combining split blocks and yielding subprocess-based test functions.

**Codebase refactoring and utilities:**

* Refactored code block compilation logic by introducing the `_build_source` function, which assembles source code and path for subprocess execution, and updated `compile_code_blocks` to use it. [[1]](diffhunk://#diff-55c110f8fdddbdcc27902a905b5431f7bb0b143349b7e2c8f27cfa802e10e981L219-R238) [[2]](diffhunk://#diff-e65aae62d3e9f0d9f1be74cb3bc744a32d225be2b1fb5c80f3f608a602181a22L5-R7)

**Testing and documentation:**

* Added extensive tests in `tests/test_splitting.py` covering subprocess execution, split blocks, interleaved tests, and various failure modes (exit codes, signals), ensuring robustness.
* Updated the `README.md` to document subprocess mode, its syntax, limitations, and sample output reflecting subprocess test results. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R454-R531) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R673-R675)

These changes provide a robust mechanism for running isolated tests directly from Markdown files, improving the reliability and flexibility of the testing framework.