### PR TITLE
Add marks support

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,83 @@ assert _setup_value == 99
 > features require the in-process test runner. If a test needs fixtures,
 > omit `subprocess: true`.
 
+Marks
+-----
+
+Add `mark: <expression>` to apply any
+[pytest mark](https://docs.pytest.org/en/stable/how-to/mark.html) to a
+test. The expression is evaluated as `pytest.mark.<expression>`.
+
+### Expected failure
+
+``````
+<!-- name: test_divide_by_zero; mark: xfail(raises=ZeroDivisionError) -->
+```python
+1 / 0
+```
+``````
+
+<!-- name: test_divide_by_zero; mark: xfail(raises=ZeroDivisionError) -->
+```python
+1 / 0
+```
+
+### xfail with reason
+
+``````
+<!-- name: test_xfail_reason; mark: xfail(reason="not implemented yet") -->
+```python
+assert False, "not implemented"
+```
+``````
+
+<!-- name: test_xfail_reason; mark: xfail(reason="not implemented yet") -->
+```python
+assert False, "not implemented"
+```
+
+### Skip a test
+
+``````
+<!-- name: test_skipped; mark: skip(reason="requires network") -->
+```python
+import urllib.request
+urllib.request.urlopen("http://localhost:99999")
+```
+``````
+
+<!-- name: test_skipped; mark: skip(reason="requires network") -->
+```python
+import urllib.request
+urllib.request.urlopen("http://localhost:99999")
+```
+
+### Marks with split blocks
+
+Only the first block needs the `mark:` declaration:
+
+``````
+<!-- name: test_mark_split_demo; mark: xfail -->
+```python
+x = 1
+```
+
+<!-- name: test_mark_split_demo -->
+```python
+assert x == 2, "expected to fail"
+```
+``````
+
+<!-- name: test_mark_split_demo; mark: xfail -->
+```python
+x = 1
+```
+
+<!-- name: test_mark_split_demo -->
+```python
+assert x == 2, "expected to fail"
+```
+
 Comment syntax
 --------------
 
@@ -561,6 +638,9 @@ Available comment parameters:
   (see [Fixtures](#fixtures)).
 * `subprocess` — set to `true` to run the test in a separate Python
   process (see [Subprocess mode](#subprocess-mode)).
+* `mark` — a pytest mark expression to apply to the test
+  (see [Marks](#marks)). Examples: `xfail`, `skip(reason="...")`,
+  `xfail(raises=ZeroDivisionError)`.
 
 Fixture lists can be written in several ways:
 


### PR DESCRIPTION
This pull request adds support for applying pytest marks directly to Markdown-based tests, enabling features like expected failures and skipping tests. It introduces new parsing and collection logic for marks, updates the documentation, and includes comprehensive unit and integration tests for mark handling.

### Feature: Pytest marks support for Markdown tests

* Added support for a `mark:` parameter in Markdown test block comments, allowing any pytest mark (e.g., `xfail`, `skip`, `xfail(raises=ZeroDivisionError)`) to be applied to tests. This is documented in the `README.md` and integrated into the test collection logic. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R532-R608) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R641-R643) [[3]](diffhunk://#diff-55c110f8fdddbdcc27902a905b5431f7bb0b143349b7e2c8f27cfa802e10e981R256-R295) [[4]](diffhunk://#diff-55c110f8fdddbdcc27902a905b5431f7bb0b143349b7e2c8f27cfa802e10e981R361-R368) [[5]](diffhunk://#diff-55c110f8fdddbdcc27902a905b5431f7bb0b143349b7e2c8f27cfa802e10e981L340-R391)

### Implementation: Mark parsing and application

* Introduced `_split_marks` and `_collect_marks` functions in `markdown_pytest.py` to parse and deduplicate mark expressions, and apply them to pytest test items during collection. [[1]](diffhunk://#diff-55c110f8fdddbdcc27902a905b5431f7bb0b143349b7e2c8f27cfa802e10e981R256-R295) [[2]](diffhunk://#diff-55c110f8fdddbdcc27902a905b5431f7bb0b143349b7e2c8f27cfa802e10e981R361-R368) [[3]](diffhunk://#diff-55c110f8fdddbdcc27902a905b5431f7bb0b143349b7e2c8f27cfa802e10e981L340-R391)
* Updated test collection logic so marks from all relevant blocks are combined and applied to the test item, including support for split blocks and subprocess mode. [[1]](diffhunk://#diff-55c110f8fdddbdcc27902a905b5431f7bb0b143349b7e2c8f27cfa802e10e981R361-R368) [[2]](diffhunk://#diff-55c110f8fdddbdcc27902a905b5431f7bb0b143349b7e2c8f27cfa802e10e981L340-R391)

### Testing: Unit and integration tests for marks

* Added unit tests for `_split_marks` and `_collect_marks` in `tests/test_splitting.py`, verifying correct parsing and deduplication of mark expressions.
* Added pytester-based integration tests to ensure marks are correctly applied and their effects (xfail/skipped/etc.) are respected during test execution.

### Documentation

* Updated `README.md` to explain the new `mark:` parameter, provide usage examples for `xfail`, `skip`, and marks with split blocks, and reference the new feature in the list of available comment parameters. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R532-R608) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R641-R643)

### Miscellaneous

* Minor import adjustment in `markdown_pytest.py` to support mark evaluation.