### PR TITLE
docs: Sphinx + Furo documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,35 @@
+name: docs
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - run: uv run --group docs sphinx-build -b html docs docs/_build/html
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build/html
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/README.md
+++ b/README.md
@@ -152,8 +152,7 @@ counter["foo"] += 1
 assert counter["foo"] == 1
 ```
 
-The [pytest-subtests](https://pypi.org/project/pytest-subtests/) package
-is installed automatically as a dependency.
+Subtests support is built into pytest 9.0+ and requires no extra packages.
 
 Fixtures
 --------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,74 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(".."))
+
+project = "markdown-pytest"
+author = "Dmitry Orlov"
+copyright = "2024, Dmitry Orlov"
+release = "0.3.2"
+
+extensions = [
+    "myst_parser",
+    "sphinx_copybutton",
+]
+
+myst_enable_extensions = [
+    "colon_fence",
+    "deflist",
+    "tasklist",
+]
+
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
+
+html_theme = "furo"
+html_title = "markdown-pytest"
+
+html_theme_options = {
+    "source_repository": "https://github.com/mosquito/markdown-pytest",
+    "source_branch": "master",
+    "source_directory": "docs/",
+    "footer_icons": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/mosquito/markdown-pytest",
+            "html": """
+                <svg stroke="currentColor" fill="currentColor" stroke-width="0"
+                     viewBox="0 0 16 16">
+                  <path fill-rule="evenodd"
+                        d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59
+                           .4.07.55-.17.55-.38
+                           0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94
+                           -.09-.23-.48-.94-.82-1.13
+                           -.28-.15-.68-.52-.01-.53
+                           .63-.01 1.08.58 1.23.82
+                           .72 1.21 1.87.87 2.33.66
+                           .07-.52.28-.87.51-1.07
+                           -1.78-.2-3.64-.89-3.64-3.95
+                           0-.87.31-1.59.82-2.15
+                           -.08-.2-.36-1.02.08-2.12
+                           0 0 .67-.21 2.2.82
+                           .64-.18 1.32-.27 2-.27
+                           .68 0 1.36.09 2 .27
+                           1.53-1.04 2.2-.82 2.2-.82
+                           .44 1.1.16 1.92.08 2.12
+                           .51.56.82 1.27.82 2.15
+                           0 3.07-1.87 3.75-3.65 3.95
+                           .29.25.54.73.54 1.48
+                           0 1.07-.01 1.93-.01 2.2
+                           0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8
+                           c0-4.42-3.58-8-8-8z"/>
+                </svg>
+            """,
+            "class": "",
+        },
+    ],
+}
+
+html_static_path = ["_static"]
+
+copybutton_prompt_text = r">>> |\.\.\. |\$ "
+copybutton_prompt_is_regexp = True

--- a/docs/explanation/how_it_works.md
+++ b/docs/explanation/how_it_works.md
@@ -1,0 +1,148 @@
+# How markdown-pytest works
+
+This page explains the internals of markdown-pytest — how it finds tests,
+what it does with them, and why certain design decisions were made.
+
+## The collection phase
+
+pytest's collection phase discovers test items. markdown-pytest hooks into
+it via two standard plugin hooks:
+
+- `pytest_collect_file` — called for every file pytest encounters. The
+  plugin returns a `MarkdownFile` collector when the file extension is
+  `.md` or `.markdown`.
+- `pytest_collect_item` — the collector's `collect()` method is called to
+  produce test items.
+
+### Parsing: `parse_code_blocks()`
+
+The parser reads the Markdown file line by line using `LinesIterator`, a
+thin wrapper around a list of `(lineno, line)` pairs that supports both
+forward iteration and bounded reverse iteration.
+
+For each line that starts with ` ```python `, the parser:
+
+1. Looks backward (and, for hidden blocks, forward) for an HTML comment
+   containing metadata — see below.
+2. If no metadata is found, skips the block.
+3. If metadata is found, reads lines until the closing ` ``` ` fence.
+4. Yields a `CodeBlock` dataclass with the source lines, start line
+   number, name, and parsed arguments.
+
+### Parsing HTML comments: `parse_arguments()`
+
+This function handles two cases:
+
+**Case 1 — Comment before the block (standard form):**
+
+```
+<!-- name: test_foo -->        ← comment ends with -->
+```python                      ← parser is here
+...
+```
+```
+
+The reverse iterator looks back one non-blank line and finds `-->`. It
+then scans further back to find the opening `<!--` and extracts the
+key-value pairs.
+
+**Case 2 — Block inside the comment (hidden form):**
+
+```
+<!--
+name: test_foo
+```python                      ← parser is here, inside a comment
+...
+```
+-->
+```
+
+The reverse iterator does not find `-->` before the fence. The parser
+then scans forward to find either `<!--` (meaning the block is not inside
+a comment — skip it) or `-->` (meaning the block is inside the comment —
+extract metadata from the lines between `<!--` and the fence).
+
+### Grouping blocks: `compile_tests()`
+
+After all `CodeBlock` objects are collected from the file, they are
+grouped by name. Blocks with the same name are sorted by line number and
+form one test.
+
+### Building source: `_build_source()`
+
+For a group of blocks, the plugin creates a source string of length equal
+to the last line of the last block. Each block's lines are placed at their
+original line numbers. Gaps are filled with empty strings. This preserves
+line numbers in tracebacks: if a block starts at line 42, an
+`AssertionError` on its first line reports `file.md:42`.
+
+## The execution phase
+
+Each test is a `MarkdownTest` item — a subclass of `pytest.Item`. Its
+`runtest()` method:
+
+1. Resolves requested fixtures using pytest's standard fixture resolution.
+2. Compiles the source with `compile()` (using `PyCF_ALLOW_TOP_LEVEL_AWAIT`
+   for async tests).
+3. Executes the compiled code with `exec()` in a namespace that includes
+   the injected fixture values.
+
+### Subtests
+
+When `case:` blocks are present, each case block is wrapped in:
+
+```{code-block} python
+with __markdown_pytest_subtests_fixture.test(msg='case_name line=N'):
+    # case block code
+```
+
+The `subtests` fixture (built into pytest 9+) is automatically added to
+the fixture list.
+
+### Subprocess mode
+
+For `subprocess: true` tests, `runtest()`:
+
+1. Writes the combined source to a temporary file.
+2. For async code, wraps the source in `async def __amain(): ...; asyncio.run(__amain())`.
+3. Calls `subprocess.run([sys.executable, tmpfile])`.
+4. Fails the test if the return code is non-zero, showing stderr as the
+   failure message.
+
+### REPL / doctest mode
+
+For `repl: true` tests, the source is parsed by Python's `doctest` module
+into a `DocTestRunner`. The runner executes each `>>>` example and compares
+output. Failures are reported with the standard doctest diff format.
+
+## Why HTML comments?
+
+Alternative approaches considered:
+
+- **YAML front matter** — would require all Markdown files to have front
+  matter blocks. Not idiomatic for documentation files.
+- **Special fence info strings** — ` ```python name=test_foo ` — not
+  supported by most Markdown renderers; breaks syntax highlighting.
+- **Separate `.yaml` sidecar files** — cumbersome; breaks the connection
+  between test and example.
+
+HTML comments are the only invisible, parseable construct available in
+standard Markdown. They are ignored by all renderers and can contain
+arbitrary text. The downside is that they require a line-by-line parser
+rather than a standard Markdown AST parser — but this keeps the dependency
+list short and makes parsing fast.
+
+## Why line-by-line parsing?
+
+A full Markdown AST parser (like `mistune` or `markdown-it-py`) would need
+to expose comment nodes with their positions, which most parsers do not do.
+It would also be an additional dependency. The hand-written line iterator
+is 150 lines and handles the only cases that matter for test collection.
+
+## Source line number preservation
+
+Tracebacks pointing to the original Markdown file is a deliberate design
+goal. The implementation pads the compiled source with blank lines so that
+the Python line numbers match Markdown line numbers. This means a failing
+test always shows the exact line to jump to, even in a file with thousands
+of lines of prose.

--- a/docs/how-to/ci.md
+++ b/docs/how-to/ci.md
@@ -1,0 +1,144 @@
+# How to run Markdown tests in CI
+
+Adding Markdown tests to continuous integration ensures that documentation
+examples are verified on every push. This page shows configurations for the
+most common CI platforms.
+
+## GitHub Actions
+
+### Minimal workflow
+
+```{code-block} yaml
+# .github/workflows/docs-tests.yml
+name: docs-tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install markdown-pytest
+      - run: pytest -v README.md
+```
+
+### Combined with existing tests
+
+```{code-block} yaml
+- run: pip install markdown-pytest pytest
+- run: pytest -v tests/ README.md docs/
+```
+
+### Matrix over Python versions
+
+```{code-block} yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install markdown-pytest
+      - run: pytest -v README.md
+```
+
+### With async support
+
+```{code-block} yaml
+- run: pip install "markdown-pytest[async]"
+- run: pytest -v README.md
+```
+
+Add this to `pyproject.toml` so pytest-asyncio uses auto mode:
+
+```{code-block} toml
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+```
+
+### With uv (faster installs)
+
+```{code-block} yaml
+- uses: astral-sh/setup-uv@v3
+- run: uv run pytest -v README.md
+```
+
+Requires the project to be a `uv` project with markdown-pytest in the
+dependencies.
+
+## GitLab CI
+
+```{code-block} yaml
+# .gitlab-ci.yml
+test-docs:
+  image: python:3.12
+  script:
+    - pip install markdown-pytest
+    - pytest -v README.md docs/
+```
+
+## Makefile target
+
+Add a `make` target for local convenience that mirrors CI:
+
+```{code-block} makefile
+.PHONY: test-docs
+test-docs:
+	pytest -v README.md docs/
+```
+
+## Reporting
+
+Use `--tb=short` in CI to get compact tracebacks:
+
+```{code-block} bash
+pytest -v --tb=short README.md
+```
+
+Use JUnit XML output for CI result dashboards:
+
+```{code-block} bash
+pytest -v --junitxml=results.xml README.md
+```
+
+In GitHub Actions, use the `dorny/test-reporter` action to display results
+inline on the PR.
+
+## Common CI gotchas
+
+**Missing dependencies for documentation examples**
+
+If your Markdown examples import a package that is not installed in the CI
+environment, the test fails with `ModuleNotFoundError`. Either install the
+package, or add `mark: skip(reason="requires X")` to that test.
+
+**Async tests fail in CI but pass locally**
+
+Ensure `asyncio_mode = "auto"` is set in `pyproject.toml` — some CI
+environments do not inherit local settings files.
+
+**Tests pass locally but fail in CI on Windows**
+
+Path separator differences (`/` vs `\`) can cause failures. Use
+`pathlib.Path` instead of string paths in your examples.
+
+**Line endings on Windows**
+
+GitHub Actions checks out files with `\r\n` on Windows by default. If your
+Markdown tests contain shell commands or string comparisons that are
+sensitive to line endings, add:
+
+```{code-block} yaml
+- uses: actions/checkout@v4
+  with:
+    eol: lf
+```

--- a/docs/how-to/conftest.md
+++ b/docs/how-to/conftest.md
@@ -1,0 +1,196 @@
+# How to use conftest.py with Markdown tests
+
+`conftest.py` is pytest's standard place for shared fixtures, hooks, and
+plugins. Everything you can do in `conftest.py` for regular Python tests
+works equally well for Markdown tests.
+
+## Where to put conftest.py
+
+pytest searches for `conftest.py` files starting from the directory of the
+collected file up to the rootdir. For Markdown tests in the project root:
+
+```{code-block} text
+project/
+  conftest.py      ← applies to all tests in project/
+  README.md
+  docs/
+    conftest.py    ← applies only to docs/
+    guide.md
+  tests/
+    conftest.py    ← applies only to tests/
+    test_app.py
+```
+
+A `conftest.py` in the same directory as the Markdown file is the most
+common placement.
+
+## Defining a simple fixture
+
+```{code-block} python
+# conftest.py
+import pytest
+
+@pytest.fixture
+def base_url():
+    return "https://example.com"
+```
+
+Use it in Markdown:
+
+````{code-block} markdown
+<!-- name: test_url; fixtures: base_url -->
+```python
+assert base_url.startswith("https://")
+assert "example.com" in base_url
+```
+````
+
+## Fixture with setup and teardown
+
+```{code-block} python
+# conftest.py
+import pytest
+
+@pytest.fixture
+def temp_database(tmp_path):
+    db_path = tmp_path / "test.db"
+    # setup
+    db_path.write_bytes(b"")
+    yield db_path
+    # teardown — runs after the test
+    db_path.unlink(missing_ok=True)
+```
+
+The fixture can itself use `tmp_path` — that is a built-in pytest fixture
+available to all fixtures.
+
+## Parametrised fixtures
+
+Fixtures can be parametrised. Each parameter value creates a separate test
+invocation:
+
+```{code-block} python
+# conftest.py
+import pytest
+
+@pytest.fixture(params=["sqlite", "postgres"])
+def db_engine(request):
+    return request.param
+```
+
+A Markdown test using `db_engine` runs twice — once with `"sqlite"` and
+once with `"postgres"`.
+
+## Session-scoped fixtures
+
+Use `scope="session"` for expensive resources that should be created once
+for the entire test run:
+
+```{code-block} python
+# conftest.py
+import pytest
+
+@pytest.fixture(scope="session")
+def compiled_schema():
+    import json
+    with open("schema.json") as f:
+        return json.load(f)
+```
+
+Session-scoped fixtures are shared across all tests in the session,
+including Markdown tests.
+
+## autouse fixtures
+
+An `autouse=True` fixture runs for every test without being declared in the
+`fixtures:` list:
+
+```{code-block} python
+# conftest.py
+import pytest
+
+@pytest.fixture(autouse=True)
+def reset_global_state():
+    import mylib
+    mylib.reset()
+    yield
+    mylib.reset()
+```
+
+All tests — Python and Markdown — receive this fixture automatically.
+
+## Fixture factories
+
+A factory fixture returns a callable that creates objects on demand:
+
+```{code-block} python
+# conftest.py
+import pytest
+
+@pytest.fixture
+def make_user():
+    created = []
+
+    def factory(name, role="viewer"):
+        user = {"name": name, "role": role}
+        created.append(user)
+        return user
+
+    yield factory
+    # teardown: clean up all created users
+    for user in created:
+        print(f"cleaning up {user['name']}")
+```
+
+Use in Markdown:
+
+````{code-block} markdown
+<!-- name: test_users; fixtures: make_user -->
+```python
+alice = make_user("Alice", role="admin")
+bob = make_user("Bob")
+assert alice["role"] == "admin"
+assert bob["role"] == "viewer"
+```
+````
+
+## Combining conftest fixtures with split blocks
+
+When a test spans multiple blocks, conftest fixtures requested in the first
+block are available in all subsequent blocks. You can also pull in
+additional conftest fixtures in later blocks — they are merged:
+
+````{code-block} markdown
+<!-- name: test_pipeline; fixtures: make_user -->
+```python
+alice = make_user("Alice", role="admin")
+```
+
+<!-- name: test_pipeline; fixtures: tmp_path -->
+```python
+path = tmp_path / "users.json"
+import json
+path.write_text(json.dumps([alice]))
+```
+
+<!-- name: test_pipeline -->
+```python
+data = json.loads(path.read_text())
+assert data[0]["name"] == "Alice"
+```
+````
+
+## Debugging fixture issues
+
+If a fixture is not found, pytest raises `FixtureLookupError` with the
+fixture name and a list of available fixtures. Common causes:
+
+- Typo in the fixture name in the `fixtures:` declaration.
+- `conftest.py` is in a parent directory that pytest does not scan.
+- The fixture is defined in a file that is not a `conftest.py`.
+
+To see all available fixtures:
+
+```{code-block} bash
+pytest --fixtures guide.md
+```

--- a/docs/how-to/marks.md
+++ b/docs/how-to/marks.md
@@ -1,0 +1,143 @@
+# How to use pytest marks
+
+pytest marks let you attach metadata to tests — skip them, mark them as
+expected failures, or tag them for selective runs. markdown-pytest supports
+the full marks system via the `mark:` key in the HTML comment.
+
+## Basic syntax
+
+```{code-block} markdown
+<!-- name: test_name; mark: <expression> -->
+```
+
+The expression is evaluated as `pytest.mark.<expression>`. Everything after
+`mark:` is passed directly to pytest's mark machinery.
+
+## Skip a test
+
+```{code-block} markdown
+<!-- name: test_needs_network; mark: skip(reason="requires network access") -->
+```
+
+The test is collected but skipped. It appears as `s` in the summary:
+
+```{code-block} text
+guide.md::test_needs_network SKIPPED (requires network access)
+```
+
+### Conditional skip
+
+Use `skipif` to skip based on a runtime condition:
+
+```{code-block} markdown
+<!-- name: test_unix_only; mark: skipif(sys.platform == "win32", reason="POSIX only") -->
+```
+
+Note: the expression is evaluated at collection time, so `sys` must be
+importable without additional setup (it always is).
+
+## Mark a test as expected to fail
+
+`xfail` marks a test that is known to fail. It passes (as `x`) if it
+fails, and surprises (as `X`) if it unexpectedly passes.
+
+```{code-block} markdown
+<!-- name: test_known_bug; mark: xfail(reason="issue #42, not fixed yet") -->
+```
+
+### Expected failure with a specific exception
+
+```{code-block} markdown
+<!-- name: test_divide_by_zero; mark: xfail(raises=ZeroDivisionError) -->
+```python
+1 / 0
+```
+```
+
+If the block raises `ZeroDivisionError`, the test is marked `xfail` (as
+expected). If it raises a different exception, the test fails.
+
+### Strict xfail
+
+`strict=True` turns an unexpected pass into a test failure:
+
+```{code-block} markdown
+<!-- name: test_strict_xfail; mark: xfail(strict=True, reason="must fail") -->
+```
+
+Use this when a test _must_ fail — an unexpected pass means the bug was
+fixed and the mark should be removed.
+
+## Apply multiple marks
+
+Use semicolons to add more metadata keys, but each test supports only one
+`mark:` value. To apply multiple marks, use comma-separated `mark.` calls
+in a single expression — or use a custom mark:
+
+```{code-block} markdown
+<!-- name: test_slow_network; mark: xfail(reason="slow"); mark: skip(reason="no network") -->
+```
+
+When `mark:` appears multiple times, the values are merged — both marks
+are applied.
+
+## Marks with split blocks
+
+Only the **first** block needs the `mark:` declaration. Subsequent blocks
+with the same name inherit the mark:
+
+```{code-block} markdown
+<!-- name: test_marked_split; mark: xfail -->
+```python
+x = 1
+```
+
+<!-- name: test_marked_split -->
+```python
+assert x == 2   # fails — expected
+```
+```
+
+## Custom marks
+
+Register your custom marks in `pyproject.toml`:
+
+```{code-block} toml
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "integration: requires external services",
+]
+```
+
+Then use them in Markdown:
+
+```{code-block} markdown
+<!-- name: test_heavy; mark: slow -->
+```python
+import time
+time.sleep(0.001)
+assert True
+```
+```
+
+Run only fast tests:
+
+```{code-block} bash
+pytest guide.md -m "not slow"
+```
+
+## Selecting tests by mark
+
+All standard `-m` expressions work:
+
+```{code-block} bash
+pytest guide.md -m "not slow"
+pytest guide.md -m "integration or smoke"
+pytest guide.md -m "xfail"
+```
+
+## Reference
+
+See the full list of built-in marks in the
+[pytest marks documentation](https://docs.pytest.org/en/stable/how-to/mark.html).

--- a/docs/how-to/mixing_languages.md
+++ b/docs/how-to/mixing_languages.md
@@ -1,0 +1,166 @@
+# How to mix Python and non-Python code blocks
+
+Markdown files that serve as documentation often contain code examples in
+many languages — shell commands, JSON config, YAML, SQL, and more. markdown-
+pytest collects only Python blocks that have a `name:` comment; everything
+else is ignored.
+
+## What is ignored
+
+The following block types are **always** skipped:
+
+- Blocks tagged with any language other than `python` (`` ```bash ``,
+  `` ```json ``, `` ```yaml ``, `` ```sql ``, etc.)
+- Blocks with no language tag (bare ` ``` `)
+- Python blocks without a `<!-- name: ... -->` comment above them
+- Blocks inside HTML comments that do not contain test metadata
+
+## Shell command examples
+
+Shell blocks pass through untouched:
+
+````{code-block} markdown
+```bash
+pip install mypackage
+```
+
+```bash
+$ mypackage --version
+1.2.3
+```
+````
+
+Both are invisible to pytest and cause no issues.
+
+## JSON / YAML / TOML configuration examples
+
+````{code-block} markdown
+```json
+{
+  "host": "localhost",
+  "port": 5432
+}
+```
+
+```yaml
+services:
+  db:
+    image: postgres:16
+```
+
+```toml
+[tool.mypackage]
+debug = true
+```
+````
+
+All ignored. Only ` ```python ` blocks are considered.
+
+## Bare code blocks
+
+Blocks with no language tag are also ignored:
+
+````{code-block} markdown
+```
+This is a plain text block.
+It is not Python.
+```
+````
+
+## Python blocks without a name comment
+
+A Python block without the `<!-- name: ... -->` comment is not collected:
+
+````{code-block} markdown
+```python
+# This block has no name comment — it is ignored by markdown-pytest
+x = 1 + 1
+```
+````
+
+This is by design — you can have documentation examples that are not tests.
+
+## The `--md-prefix` option and ignoring blocks
+
+By default, only names starting with `test` are collected. A Python block
+with `<!-- name: example_foo -->` (no `test` prefix) is silently ignored.
+This lets you use the comment syntax for other purposes without accidentally
+creating tests.
+
+## Mixed-language file example
+
+A full README might look like:
+
+````{code-block} text
+## Installation
+
+```bash
+pip install mypackage
+```
+
+## Configuration
+
+```yaml
+mypackage:
+  debug: false
+```
+
+## Usage
+
+<!-- name: test_basic_usage -->
+```python
+import mypackage
+result = mypackage.process([1, 2, 3])
+assert result == [2, 4, 6]
+```
+
+Here is what the output looks like:
+
+```
+[2, 4, 6]
+```
+
+## API
+
+```python
+# This block shows the function signature — not a test
+def process(items: list[int]) -> list[int]:
+    ...
+```
+````
+
+From this file, pytest collects exactly one test: `test_basic_usage`. All
+other blocks are ignored.
+
+## Indented blocks inside HTML elements
+
+Code blocks inside `<details>` or similar HTML elements may be indented.
+The plugin strips the leading indentation automatically:
+
+````{code-block} markdown
+<details>
+<summary>Show example</summary>
+
+    <!-- name: test_inside_details -->
+    ```python
+    assert 1 + 1 == 2
+    ```
+
+</details>
+````
+
+The four-space indentation caused by the `<details>` wrapper is removed
+during parsing.
+
+## Four-backtick fences
+
+Fences using four backticks (```` ```` ````) instead of three are also
+ignored, even if tagged as `python`. This is useful for showing Markdown
+source that contains triple-backtick fences:
+
+`````{code-block} markdown
+````python
+# This looks like Python but uses four backticks — ignored by markdown-pytest
+x = 1
+````
+`````

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,116 @@
+# markdown-pytest
+
+[![PyPI Version](https://img.shields.io/pypi/v/markdown-pytest.svg)](https://pypi.python.org/pypi/markdown-pytest/)
+[![Python Versions](https://img.shields.io/pypi/pyversions/markdown-pytest.svg)](https://pypi.python.org/pypi/markdown-pytest/)
+[![License](https://img.shields.io/pypi/l/markdown-pytest.svg)](https://pypi.python.org/pypi/markdown-pytest/)
+[![Tests](https://github.com/mosquito/markdown-pytest/workflows/tests/badge.svg)](https://github.com/mosquito/markdown-pytest/actions)
+
+**markdown-pytest** is a pytest plugin that collects and runs Python code
+blocks directly from Markdown files, so your documentation examples are
+always tested and never go stale.
+
+```{code-block} text
+$ pytest -v README.md
+
+README.md::test_quick_start PASSED
+README.md::test_example PASSED
+README.md::test_with_tmp_path PASSED
+```
+
+## Why test your documentation?
+
+Documentation examples rot. A library evolves, an API changes, someone
+updates the code but forgets the README — and now your users copy-paste
+broken examples. markdown-pytest solves this by running every Python code
+block in your Markdown files as a real pytest test.
+
+Because the test markers are plain HTML comments, rendered documentation
+looks completely normal. Readers see clean code blocks; pytest sees a full
+test suite.
+
+## Features at a glance
+
+- **Zero-config collection** — install and run `pytest docs/` or
+  `pytest README.md`. No extra configuration needed.
+- **Code splitting** — spread a single test across multiple code blocks,
+  with prose in between, the way you would naturally write a tutorial.
+- **Fixtures** — use `tmp_path`, `monkeypatch`, `capsys`, or any custom
+  fixture from `conftest.py` directly in your Markdown code blocks.
+- **Subtests** — run independent sub-cases sharing a common setup, powered
+  by pytest's built-in subtests support (pytest 9+).
+- **Hidden blocks** — hide setup or assertion code inside HTML comments so
+  readers see only the interesting part.
+- **Subprocess isolation** — run a block in a fresh Python process for
+  tests that mutate global state or call `sys.exit()`.
+- **Async support** — prefix a test name with `async ` to enable
+  top-level `await` and async fixtures.
+- **REPL / doctest mode** — write blocks in interactive Python shell
+  format (`>>> ...`) and check their output.
+- **Marks** — apply `xfail`, `skip`, or any custom mark directly from the
+  comment.
+
+## Quickstart
+
+```{code-block} bash
+pip install markdown-pytest
+```
+
+Add a comment above a Python code block in any `.md` file:
+
+````{code-block} markdown
+<!-- name: test_addition -->
+```python
+assert 1 + 1 == 2
+```
+````
+
+Run:
+
+```{code-block} bash
+pytest README.md
+```
+
+That's it. Jump to the {doc}`tutorial/01_first_test` for a complete
+walkthrough.
+
+## Navigation
+
+```{toctree}
+:maxdepth: 2
+:caption: Tutorials
+
+tutorial/01_first_test
+tutorial/02_split_blocks
+tutorial/03_fixtures
+tutorial/04_subtests
+tutorial/05_hidden_blocks
+tutorial/06_async
+tutorial/07_subprocess
+tutorial/08_doctest
+```
+
+```{toctree}
+:maxdepth: 2
+:caption: How-to guides
+
+how-to/marks
+how-to/conftest
+how-to/ci
+how-to/mixing_languages
+```
+
+```{toctree}
+:maxdepth: 2
+:caption: Reference
+
+reference/comment_syntax
+reference/configuration
+reference/environments
+```
+
+```{toctree}
+:maxdepth: 2
+:caption: Explanation
+
+explanation/how_it_works
+```

--- a/docs/reference/comment_syntax.md
+++ b/docs/reference/comment_syntax.md
@@ -1,0 +1,215 @@
+# Comment syntax reference
+
+The HTML comment placed above (or around) a Python code block is the only
+configuration interface for markdown-pytest. This page documents every
+parameter and every valid syntax variant.
+
+## Basic structure
+
+```{code-block} text
+<!-- key1: value1; key2: value2 -->
+```
+
+- Key-value pairs are separated by semicolons (`;`).
+- The trailing semicolon after the last pair is optional.
+- Whitespace around keys and values is stripped.
+- Comments can span multiple lines.
+
+## Parameters
+
+### `name` (required)
+
+The test identifier. Must be unique per file (within a given name,
+all blocks are merged into one test).
+
+```{code-block} text
+<!-- name: test_my_feature -->
+```
+
+**Rules:**
+
+- Must start with the configured prefix (`test` by default — see
+  {doc}`configuration`).
+- Must be a valid Python identifier: letters, digits, and underscores.
+  No spaces (spaces before the prefix `async ` are the only exception).
+- Case-sensitive: `test_foo` and `test_Foo` are two different tests.
+
+**Async prefix:**
+
+Prefix the name with `async ` to enable top-level `await`:
+
+```{code-block} text
+<!-- name: async test_my_async_feature -->
+```
+
+The `async ` part is stripped from the collected test name — the test
+is named `test_my_async_feature` in pytest output.
+
+### `case`
+
+Marks a block as a subtest. The first block with a given name and no
+`case:` key is the shared setup; each `case:` block is an independent
+subtest that runs after the setup.
+
+```{code-block} text
+<!-- name: test_foo; case: my_scenario -->
+```
+
+- Case names can contain spaces: `case: handles empty input`.
+- If all blocks have `case:`, there is no shared setup — each case
+  runs in its own fresh namespace.
+- Subtests require pytest 9.0+.
+
+### `fixtures`
+
+Comma-separated list of pytest fixture names to inject as variables.
+
+```{code-block} text
+<!-- name: test_foo; fixtures: tmp_path, monkeypatch, capsys -->
+```
+
+The fixture values are available as variables with the same names inside
+the code block.
+
+**Multiline form:**
+
+```{code-block} text
+<!--
+    name: test_foo;
+    fixtures: tmp_path,
+              monkeypatch,
+              capsys
+-->
+```
+
+**Multiple `fixtures:` keys:**
+
+```{code-block} text
+<!--
+    name: test_foo;
+    fixtures: tmp_path;
+    fixtures: monkeypatch
+-->
+```
+
+Duplicate keys are merged — the two forms above are equivalent.
+
+**Only the first block needs `fixtures:`** when a test is split across
+multiple blocks. Later blocks share the same namespace.
+
+### `subprocess`
+
+Set to `true` to run the test in a separate Python process.
+
+```{code-block} text
+<!-- name: test_isolated; subprocess: true -->
+```
+
+- Fixtures and `case:` subtests are not available in subprocess mode.
+- Async code is wrapped in `asyncio.run()` automatically.
+- The child process inherits the parent's `sys.path`.
+- A non-zero exit code fails the test.
+
+### `repl`
+
+Set to `true` to run the block as a doctest (interactive shell session).
+
+```{code-block} text
+<!-- name: test_session; repl: true -->
+```
+
+- Lines starting with `>>>` are executed.
+- Lines starting with `...` are continuation lines.
+- Following lines without a prompt are expected output.
+- All standard `# doctest: +DIRECTIVE` flags are supported.
+- Cannot be combined with `subprocess: true`.
+
+### `mark`
+
+A pytest mark expression, evaluated as `pytest.mark.<expression>`.
+
+```{code-block} text
+<!-- name: test_foo; mark: xfail(raises=ValueError) -->
+<!-- name: test_bar; mark: skip(reason="not implemented") -->
+<!-- name: test_baz; mark: skipif(sys.platform == "win32", reason="POSIX only") -->
+```
+
+Multiple `mark:` keys are merged — all marks are applied:
+
+```{code-block} text
+<!--
+    name: test_multi;
+    mark: xfail;
+    mark: slow
+-->
+```
+
+## Comment delimiters
+
+Both two-dash and three-dash variants are recognised. All four forms are
+equivalent:
+
+```{code-block} text
+<!--  name: test_foo -->
+<!--- name: test_foo --->
+<!--  name: test_foo --->
+<!--- name: test_foo -->
+```
+
+## Hidden block syntax
+
+A code block placed **inside** the comment is hidden from rendered
+Markdown but executed as part of the test. The metadata keys come first,
+then the code fence:
+
+```{code-block} text
+<!--
+name: test_foo;
+fixtures: tmp_path
+```python
+p = tmp_path / "f.txt"
+```
+-->
+```
+
+The closing `-->` appears **after** the closing ` ``` `. The opening
+` ```python ` and closing ` ``` ` are part of the comment.
+
+## Full example
+
+A test with all parameters used together:
+
+```{code-block} text
+<!--
+    name: async test_full_example;
+    fixtures: tmp_path, monkeypatch;
+    mark: xfail(strict=False, reason="experimental")
+    ```python
+    # hidden setup block
+    import json
+    path = tmp_path / "data.json"
+    ```
+-->
+```python
+# visible block — readers see this
+path.write_text(json.dumps({"key": "value"}))
+```
+<!--
+name: async test_full_example
+```python
+# hidden assertions
+data = json.loads(path.read_text())
+assert data["key"] == "value"
+```
+-->
+```
+
+## Ignored blocks
+
+A Python block is **silently ignored** when:
+
+- It has no comment above (or around) it.
+- The comment has no `name:` key.
+- The `name:` value does not start with the configured prefix.
+- The block uses a language tag other than `python`.
+- The block uses a non-triple backtick fence.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,0 +1,102 @@
+# Configuration reference
+
+markdown-pytest adds one command-line option to pytest and respects the
+standard pytest configuration files.
+
+## `--md-prefix`
+
+Controls which test names are collected from Markdown files.
+
+**Default:** `test`
+
+Only code blocks whose `name:` value starts with this prefix are collected.
+Blocks with names that do not match the prefix are silently ignored.
+
+### Command-line
+
+```{code-block} bash
+pytest --md-prefix=check README.md
+```
+
+With this setting, `<!-- name: check_addition -->` is collected and
+`<!-- name: test_addition -->` is not.
+
+### pyproject.toml
+
+```{code-block} toml
+[tool.pytest.ini_options]
+addopts = "--md-prefix=check"
+```
+
+### pytest.ini
+
+```{code-block} ini
+[pytest]
+addopts = --md-prefix=check
+```
+
+### setup.cfg
+
+```{code-block} ini
+[tool:pytest]
+addopts = --md-prefix=check
+```
+
+## asyncio_mode
+
+Not a markdown-pytest option, but required for async Markdown tests.
+
+```{code-block} toml
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+```
+
+Without this, pytest-asyncio does not run `async def` test functions
+automatically. Since Markdown tests cannot be decorated with
+`@pytest.mark.asyncio`, `auto` mode is required for async Markdown tests.
+
+## Collected file extensions
+
+Both `.md` and `.markdown` files are collected automatically via the
+`pytest_collect_file` hook. No configuration is needed.
+
+To restrict collection to a specific directory or file pattern, use pytest's
+standard `testpaths` and `python_files` settings — though `python_files`
+does not affect Markdown collection (it only controls `.py` files).
+
+To collect Markdown files from a specific directory:
+
+```{code-block} bash
+pytest docs/
+```
+
+To exclude a directory:
+
+```{code-block} bash
+pytest --ignore=docs/drafts README.md docs/
+```
+
+## Markers
+
+If you use custom `mark:` expressions in your Markdown comments, register
+the markers to suppress pytest warnings:
+
+```{code-block} toml
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests as slow",
+    "integration: requires external services",
+]
+```
+
+## Full pyproject.toml example
+
+```{code-block} toml
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+addopts = "-v --tb=short"
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "integration: requires real network or database",
+]
+```

--- a/docs/reference/environments.md
+++ b/docs/reference/environments.md
@@ -1,0 +1,99 @@
+# Supported environments
+
+## Python versions
+
+| Version | Status |
+|---------|--------|
+| 3.10 | Supported |
+| 3.11 | Supported |
+| 3.12 | Supported |
+| 3.13 | Supported |
+| 3.14 | Supported |
+| PyPy 3.10+ | Supported |
+| < 3.10 | Not supported |
+
+The minimum version is Python 3.10 because the plugin uses
+`str.removeprefix()` and structural pattern matching internally.
+
+## pytest versions
+
+| Version | Status |
+|---------|--------|
+| 9.0+ | Supported (subtests built-in) |
+| < 9.0 | Not supported |
+
+pytest 9.0 is the minimum version. It introduced built-in subtests support,
+which markdown-pytest relies on for the `case:` feature.
+
+## Operating systems
+
+Tested on Linux, macOS, and Windows. Path handling uses `pathlib` throughout,
+so cross-platform behaviour is consistent.
+
+## Optional dependencies
+
+### pytest-asyncio
+
+Required for async tests (`name: async test_...`).
+
+```{code-block} bash
+pip install "markdown-pytest[async]"
+# equivalent to:
+pip install markdown-pytest pytest-asyncio
+```
+
+Compatible versions: `pytest-asyncio >= 1, < 2`.
+
+### Other async plugins
+
+Any pytest plugin that can run `async def` test functions works:
+
+- `aiomisc-pytest`
+- `anyio` (with `pytest-anyio`)
+- Custom event loop plugins
+
+Without an async plugin, async tests fail immediately with a clear error
+message.
+
+## File extensions collected
+
+| Extension | Collected |
+|-----------|-----------|
+| `.md` | Yes |
+| `.markdown` | Yes |
+| `.rst` | No |
+| `.txt` | No |
+
+## Tracebacks
+
+Tracebacks from failing tests preserve the original Markdown line numbers.
+A failure in a code block at line 42 of `README.md` reports:
+
+```{code-block} text
+README.md:42: AssertionError
+```
+
+This works because the plugin compiles code with `filename=<path>` and
+inserts blank lines to pad line numbers to match the Markdown source.
+
+## pytest plugins compatibility
+
+markdown-pytest is compatible with:
+
+- `pytest-cov` (coverage)
+- `pytest-xdist` (parallel execution)
+- `pytest-timeout`
+- `pytest-randomly`
+- Any plugin that hooks into pytest's standard collection and execution.
+
+## Entry point
+
+The plugin registers itself via the `pytest11` entry point:
+
+```{code-block} toml
+[project.entry-points.pytest11]
+markdown-pytest = "markdown_pytest"
+```
+
+No `conftest.py` import or `pytest_plugins` declaration is needed. Install
+the package and pytest finds the plugin automatically.

--- a/docs/tutorial/01_first_test.md
+++ b/docs/tutorial/01_first_test.md
@@ -1,0 +1,205 @@
+# Tutorial 1 — Your first Markdown test
+
+In this tutorial you will install markdown-pytest, write a Python code block
+in a Markdown file, mark it as a test with an HTML comment, and run it with
+pytest. The whole thing takes about five minutes.
+
+## Prerequisites
+
+- Python 3.10 or newer
+- `pip` available in your shell
+
+No prior pytest knowledge is required, although it helps to know what a
+test function looks like.
+
+## Step 1 — Install
+
+```{code-block} bash
+pip install markdown-pytest
+```
+
+That is all you need. The package registers itself as a pytest plugin via
+the `pytest11` entry point, so pytest discovers it automatically — no
+`conftest.py` or `pytest_plugins` declaration is needed.
+
+To verify the installation:
+
+```{code-block} bash
+pytest --co -q README.md   # --co = collect only, -q = quiet
+```
+
+If markdown-pytest is installed and the file contains marked blocks, you
+will see the test names listed. If the file has no marked blocks yet, the
+output is empty — that is fine.
+
+## Step 2 — Create a Markdown file
+
+Create a file called `guide.md` in the root of your project (or open an
+existing one).
+
+The file can be anything — a README, a tutorial, API documentation, a
+changelog. markdown-pytest ignores all content it does not recognise, so
+you can add tests incrementally to files that already exist.
+
+## Step 3 — Write a code block and mark it as a test
+
+Paste the following into `guide.md`:
+
+````{code-block} markdown
+# My library
+
+Here is a quick example:
+
+<!-- name: test_addition -->
+```python
+result = 1 + 1
+assert result == 2
+```
+````
+
+The `<!-- name: test_addition -->` comment is the only thing markdown-pytest
+needs. It tells the plugin:
+
+- this block exists (not ignored)
+- the test is named `test_addition`
+
+The comment is invisible in rendered HTML — GitHub, MkDocs, Sphinx, and
+every other Markdown renderer hide HTML comments from readers.
+
+### Naming rules
+
+The name must start with `test` by default (configurable, see
+{doc}`../reference/configuration`). It follows the same conventions as a
+Python function name: letters, digits, and underscores.
+
+```{admonition} Valid names
+:class: tip
+
+`test_addition`, `test_parses_csv`, `test_edge_case_empty_list`
+```
+
+```{admonition} Invalid names — these are silently ignored
+:class: warning
+
+`addition` (no `test` prefix), `test addition` (space), `Test_Addition`
+(uppercase T — treated as a different prefix)
+```
+
+## Step 4 — Run the test
+
+```{code-block} bash
+pytest guide.md
+```
+
+Expected output:
+
+```{code-block} text
+========================= test session starts ==========================
+collected 1 item
+
+guide.md::test_addition PASSED                                   [100%]
+
+========================== 1 passed in 0.01s ===========================
+```
+
+Add `-v` for the verbose form that shows each test name on its own line:
+
+```{code-block} bash
+pytest -v guide.md
+```
+
+```{code-block} text
+========================= test session starts ==========================
+collected 1 item
+
+guide.md::test_addition PASSED                                   [100%]
+
+========================== 1 passed in 0.01s ===========================
+```
+
+## Step 5 — Make the test fail
+
+Understanding failure output is as important as knowing how to pass.
+Change the assertion:
+
+````{code-block} markdown
+<!-- name: test_addition -->
+```python
+result = 1 + 1
+assert result == 3   # wrong on purpose
+```
+````
+
+Run again:
+
+```{code-block} bash
+pytest guide.md
+```
+
+```{code-block} text
+========================= test session starts ==========================
+collected 1 item
+
+guide.md::test_addition FAILED                                   [100%]
+
+================================ FAILURES ==============================
+_______________________ test_addition __________________________
+
+guide.md:7: AssertionError
+
+======================= short test summary info ========================
+FAILED guide.md::test_addition - AssertionError
+========================= 1 failed in 0.01s ============================
+```
+
+The traceback points directly to the line in `guide.md` — not to some
+generated temp file. Fix the assertion back to `== 2` before continuing.
+
+## Step 6 — Run all Markdown files at once
+
+If your project has multiple Markdown files, point pytest at a directory:
+
+```{code-block} bash
+pytest docs/
+```
+
+Or mix Markdown with regular Python test files:
+
+```{code-block} bash
+pytest docs/ tests/
+```
+
+pytest collects `.md` and `.markdown` files automatically. Files without
+any marked blocks are silently skipped.
+
+## Step 7 — Add to CI
+
+In GitHub Actions, add a step like:
+
+```{code-block} yaml
+- name: Test documentation examples
+  run: pytest -v README.md docs/
+```
+
+Or extend an existing test step to include Markdown files alongside
+`tests/`:
+
+```{code-block} yaml
+- name: Run tests
+  run: pytest -v tests/ README.md
+```
+
+## What you learned
+
+- Install markdown-pytest with a single `pip install`.
+- Mark a Python code block by placing `<!-- name: test_... -->` directly
+  above it.
+- Run `pytest <file>.md` to execute the tests.
+- Tracebacks reference the original Markdown line numbers.
+
+## Next steps
+
+A single block per test works well for short self-contained examples. For
+longer examples with explanatory prose in between, see
+{doc}`02_split_blocks` — it shows how to spread one test across several
+code blocks.

--- a/docs/tutorial/02_split_blocks.md
+++ b/docs/tutorial/02_split_blocks.md
@@ -1,0 +1,198 @@
+# Tutorial 2 — Splitting a test across multiple blocks
+
+Good documentation tells a story. You introduce a concept, show a snippet,
+explain what happened, then build on it with another snippet. But a pytest
+test is one continuous unit — the second block needs the variables defined
+in the first.
+
+markdown-pytest solves this with **code splitting**: give several blocks
+the same `name` and they are merged into a single test at collection time,
+in document order.
+
+## Prerequisites
+
+Completed {doc}`01_first_test`. You have `guide.md` and markdown-pytest
+installed.
+
+## The problem without splitting
+
+Suppose you want to document `itertools.chain` in two steps:
+
+1. First block: import and explain the function.
+2. Second block: demonstrate it.
+
+Without splitting, each block would be its own independent test. The second
+block would fail because `chain` is not imported there.
+
+## Step 1 — Write two blocks with the same name
+
+In `guide.md`, write:
+
+````{code-block} markdown
+## Using itertools.chain
+
+Import the function first:
+
+<!-- name: test_chain_demo -->
+```python
+from itertools import chain
+```
+
+`chain` concatenates iterables without copying them:
+
+<!-- name: test_chain_demo -->
+```python
+result = list(chain([1, 2], [3, 4]))
+assert result == [1, 2, 3, 4]
+```
+````
+
+Both blocks have `name: test_chain_demo`. markdown-pytest sees them as two
+parts of one test. When the test runs, it executes:
+
+```{code-block} python
+from itertools import chain
+# (prose in between is ignored)
+result = list(chain([1, 2], [3, 4]))
+assert result == [1, 2, 3, 4]
+```
+
+Run it:
+
+```{code-block} bash
+pytest guide.md -v
+```
+
+```{code-block} text
+guide.md::test_chain_demo PASSED
+```
+
+## Step 2 — Add prose between blocks
+
+The prose between the two blocks does not affect execution. You can write as
+much explanatory text as you like — it is stripped out during collection.
+Only the Python code blocks with the matching name are combined.
+
+For example:
+
+````{code-block} markdown
+## Building a pipeline
+
+Start with a list of numbers:
+
+<!-- name: test_pipeline -->
+```python
+numbers = [1, 2, 3, 4, 5]
+```
+
+Filter to even numbers only. Python's built-in `filter` returns an
+iterator, so we wrap it in `list()` to materialise the result:
+
+<!-- name: test_pipeline -->
+```python
+evens = list(filter(lambda x: x % 2 == 0, numbers))
+```
+
+Square each even number using a list comprehension:
+
+<!-- name: test_pipeline -->
+```python
+squared = [x ** 2 for x in evens]
+assert squared == [4, 16]
+```
+````
+
+Three blocks, one test, prose between each one.
+
+## Step 3 — Non-consecutive blocks
+
+Split blocks do not need to be adjacent. A completely different test can
+appear between two blocks that share a name:
+
+````{code-block} markdown
+<!-- name: test_a -->
+```python
+x = 10
+```
+
+<!-- name: test_unrelated -->
+```python
+assert True
+```
+
+<!-- name: test_a -->
+```python
+assert x == 10   # x is from the first block — this works
+```
+````
+
+The plugin collects all blocks named `test_a` regardless of what appears
+between them. `test_unrelated` becomes its own separate test.
+
+## Step 4 — Fixtures in split blocks
+
+When using fixtures, only the **first** block needs the `fixtures:`
+declaration. All subsequent blocks with the same name automatically share
+the same namespace, including the fixture variables:
+
+````{code-block} markdown
+<!-- name: test_file_pipeline; fixtures: tmp_path -->
+```python
+src = tmp_path / "input.txt"
+src.write_text("hello\nworld\n")
+```
+
+Read and process the file in a second block — `tmp_path` and `src` are
+still in scope:
+
+<!-- name: test_file_pipeline -->
+```python
+lines = src.read_text().splitlines()
+assert len(lines) == 2
+assert lines[0] == "hello"
+```
+````
+
+See {doc}`03_fixtures` for the full guide on fixtures.
+
+## How it works internally
+
+At collection time the plugin reads the whole file and groups blocks by
+name. For each name it sorts the blocks by their line number and
+concatenates the source lines. Line numbers are preserved — if block 1 is
+at line 10 and block 2 is at line 30, the compiled source has blank lines
+filling lines 11–29 so that tracebacks still point to the right location
+in the original file.
+
+## Common mistakes
+
+**Using different names by accident**
+
+If you accidentally write `test_Chain_demo` (capital C) for the second
+block, it becomes a separate test that will fail because `chain` is not
+imported.
+
+```{admonition} Tip
+:class: tip
+
+Paste names from the first block — don't retype them. A typo creates a
+silent second test that imports nothing.
+```
+
+**Expecting ordering across files**
+
+Split blocks are combined only within a single file. Two blocks named
+`test_foo` in two different `.md` files are two separate tests, not one.
+
+## What you learned
+
+- Give two or more blocks the same `name` and they run as one test.
+- Blocks can be separated by any amount of prose.
+- Blocks do not need to be adjacent — other tests can appear in between.
+- Only the first block needs the `fixtures:` declaration.
+
+## Next steps
+
+{doc}`03_fixtures` shows every way to inject pytest fixtures into your
+Markdown tests — from simple `tmp_path` usage to multiple fixtures,
+multiline declarations, and mixing fixtures across split blocks.

--- a/docs/tutorial/03_fixtures.md
+++ b/docs/tutorial/03_fixtures.md
@@ -1,0 +1,232 @@
+# Tutorial 3 — Using fixtures
+
+pytest fixtures provide reusable, isolated resources to tests — temporary
+directories, captured output, environment variable overrides, and anything
+you define yourself. markdown-pytest gives you full access to the same
+fixture system from inside Markdown code blocks.
+
+## Prerequisites
+
+Completed {doc}`02_split_blocks`. Familiarity with at least one pytest
+fixture (`tmp_path` is the most common).
+
+## Declaring fixtures
+
+Add `fixtures: <name>` to the HTML comment. The fixture is then available
+as a variable with that exact name inside the code block.
+
+````{code-block} markdown
+<!-- name: test_tmp_file; fixtures: tmp_path -->
+```python
+p = tmp_path / "hello.txt"
+p.write_text("hello")
+assert p.read_text() == "hello"
+```
+````
+
+`tmp_path` is a built-in pytest fixture that provides a temporary directory
+unique to the test invocation. It is cleaned up automatically after the
+test.
+
+## Step 1 — Single fixture
+
+The simplest case: one fixture, one block.
+
+````{code-block} markdown
+<!-- name: test_write_file; fixtures: tmp_path -->
+```python
+path = tmp_path / "data.txt"
+path.write_text("content")
+assert path.exists()
+assert path.read_text() == "content"
+```
+````
+
+Run:
+
+```{code-block} bash
+pytest guide.md::test_write_file -v
+```
+
+```{code-block} text
+guide.md::test_write_file PASSED
+```
+
+## Step 2 — Multiple fixtures
+
+List fixtures separated by commas:
+
+````{code-block} markdown
+<!-- name: test_env_and_file; fixtures: tmp_path, monkeypatch -->
+```python
+import os
+monkeypatch.setenv("DATA_DIR", str(tmp_path))
+assert os.environ["DATA_DIR"] == str(tmp_path)
+```
+````
+
+`monkeypatch` lets you set environment variables (and much more) safely —
+changes are automatically undone after the test.
+
+## Step 3 — Multiline fixture declarations
+
+If the fixture list is long, break it across lines inside the comment:
+
+````{code-block} markdown
+<!--
+    name: test_multi;
+    fixtures: tmp_path,
+              monkeypatch,
+              capsys
+-->
+```python
+import os
+monkeypatch.setenv("X", "1")
+print(os.environ["X"])
+captured = capsys.readouterr()
+assert captured.out.strip() == "1"
+```
+````
+
+The indentation inside the comment is ignored; only the values matter.
+
+## Step 4 — Fixtures declared on separate lines
+
+Alternatively, use a separate `fixtures:` key for each fixture:
+
+````{code-block} markdown
+<!--
+    name: test_separate;
+    fixtures: tmp_path;
+    fixtures: capsys
+-->
+```python
+(tmp_path / "f.txt").write_text("hi")
+print("hi")
+captured = capsys.readouterr()
+assert captured.out.strip() == "hi"
+```
+````
+
+Duplicate keys are merged automatically — this is equivalent to listing
+them all on one line.
+
+## Step 5 — Fixtures across split blocks
+
+When a test is split into multiple blocks, declare fixtures only in the
+**first** block. All blocks with the same name share the same namespace,
+so fixtures are available everywhere:
+
+````{code-block} markdown
+<!-- name: test_split_file; fixtures: tmp_path -->
+```python
+path = tmp_path / "log.txt"
+path.write_text("line1\nline2\n")
+```
+
+Now read the file back:
+
+<!-- name: test_split_file -->
+```python
+lines = path.read_text().splitlines()
+assert lines == ["line1", "line2"]
+```
+````
+
+The second block does not repeat `fixtures: tmp_path`. `tmp_path` and
+`path` are both in scope because all blocks share one namespace.
+
+## Step 6 — Fixtures from different blocks merged
+
+You can declare different fixtures in different blocks — they are all
+requested and injected into the shared namespace:
+
+````{code-block} markdown
+<!-- name: test_merged; fixtures: tmp_path -->
+```python
+p = tmp_path / "out.txt"
+p.write_text("merged")
+```
+
+<!-- name: test_merged; fixtures: capsys -->
+```python
+print(p.read_text())
+captured = capsys.readouterr()
+assert captured.out.strip() == "merged"
+```
+````
+
+Both `tmp_path` and `capsys` are requested even though they appear in
+separate blocks.
+
+## Step 7 — Custom fixtures from conftest.py
+
+Any fixture defined in `conftest.py` works exactly the same way. Create
+`conftest.py` next to your Markdown file (or anywhere pytest can find it):
+
+```{code-block} python
+# conftest.py
+import pytest
+
+@pytest.fixture
+def sample_data():
+    return {"key": "value", "count": 42}
+```
+
+Use it in a Markdown block:
+
+````{code-block} markdown
+<!-- name: test_custom_fixture; fixtures: sample_data -->
+```python
+assert sample_data["key"] == "value"
+assert sample_data["count"] == 42
+```
+````
+
+See {doc}`../how-to/conftest` for patterns with `autouse` fixtures,
+factories, and session-scoped setup.
+
+## Common built-in fixtures
+
+| Fixture | What it provides |
+|---------|-----------------|
+| `tmp_path` | Temporary `pathlib.Path` directory, unique per test |
+| `tmp_path_factory` | Factory for creating multiple temp directories |
+| `monkeypatch` | Patch objects, env vars, and sys.path safely |
+| `capsys` | Capture `sys.stdout` and `sys.stderr` |
+| `capfd` | Capture file descriptors 1 and 2 |
+| `caplog` | Capture log records |
+| `request` | Access test metadata (name, module, config) |
+
+Any of these can be listed in the `fixtures:` declaration.
+
+## Common mistakes
+
+**Declaring fixtures in every block**
+
+Only the first block needs `fixtures:`. If you repeat the declaration in
+later blocks, the fixture is requested twice — usually harmless but
+redundant.
+
+**Typo in fixture name**
+
+If you write `fixtures: tmp_paths` (extra `s`), pytest raises
+`FixtureLookupError` because no fixture with that name exists. The error
+message lists similar names.
+
+**Scope mismatch**
+
+A session-scoped fixture cannot depend on a function-scoped fixture. This
+constraint comes from pytest itself and applies equally to Markdown tests.
+
+## What you learned
+
+- Add `fixtures: name` to inject any pytest fixture.
+- Comma-separate multiple fixtures, or use separate `fixtures:` keys.
+- Only the first split block needs the `fixtures:` declaration.
+- Custom fixtures from `conftest.py` work without any special setup.
+
+## Next steps
+
+{doc}`04_subtests` shows how to run many independent variations of a test
+that all share the same setup — without duplicating the setup code.

--- a/docs/tutorial/04_subtests.md
+++ b/docs/tutorial/04_subtests.md
@@ -1,0 +1,240 @@
+# Tutorial 4 — Subtests
+
+A subtest is an independent mini-test that shares setup with its siblings.
+If one subtest fails, the others still run — unlike a single test where the
+first failure stops execution. This is perfect for documenting a function
+with many different inputs side by side.
+
+pytest 9.0 ships subtests as a built-in feature. No extra packages are
+needed.
+
+## Prerequisites
+
+Completed {doc}`03_fixtures`. You should know how split blocks work.
+
+## The problem without subtests
+
+Suppose you want to document three edge cases for a string sanitiser:
+
+````{code-block} markdown
+<!-- name: test_sanitise_empty -->
+```python
+from mylib import sanitise
+assert sanitise("") == ""
+```
+
+<!-- name: test_sanitise_spaces -->
+```python
+from mylib import sanitise       # imported again
+assert sanitise("  hello  ") == "hello"
+```
+
+<!-- name: test_sanitise_special -->
+```python
+from mylib import sanitise       # imported again
+assert sanitise("a<b>c") == "abc"
+```
+````
+
+Three separate tests — three imports. If `sanitise` needs expensive
+setup, you repeat it three times. With subtests you set up once and vary
+the assertion:
+
+## Step 1 — Add `case:` to each variation
+
+The first block (no `case:`) is the **shared setup**. Each subsequent block
+with a `case:` key is an independent subtest.
+
+````{code-block} markdown
+<!-- name: test_sanitise -->
+```python
+def sanitise(s):
+    return s.strip().replace("<", "").replace(">", "")
+```
+
+<!-- name: test_sanitise; case: empty_string -->
+```python
+assert sanitise("") == ""
+```
+
+<!-- name: test_sanitise; case: strips_whitespace -->
+```python
+assert sanitise("  hello  ") == "hello"
+```
+
+<!-- name: test_sanitise; case: removes_angle_brackets -->
+```python
+assert sanitise("a<b>c") == "abc"
+```
+````
+
+When run:
+
+```{code-block} bash
+pytest guide.md -v
+```
+
+```{code-block} text
+guide.md::test_sanitise PASSED
+  test_sanitise/empty_string PASSED
+  test_sanitise/strips_whitespace PASSED
+  test_sanitise/removes_angle_brackets PASSED
+```
+
+Three sub-results, one test entry in the summary.
+
+## Step 2 — One failure does not stop the rest
+
+Change the second case to a wrong expected value:
+
+````{code-block} markdown
+<!-- name: test_sanitise; case: strips_whitespace -->
+```python
+assert sanitise("  hello  ") == "HELLO"   # wrong
+```
+````
+
+Run again:
+
+```{code-block} text
+guide.md::test_sanitise FAILED
+  test_sanitise/empty_string PASSED
+  test_sanitise/strips_whitespace FAILED
+  test_sanitise/removes_angle_brackets PASSED
+```
+
+`strips_whitespace` failed, but `removes_angle_brackets` still ran and
+passed. Without subtests, execution would have stopped at the first failure.
+
+Fix the assertion before continuing.
+
+## Step 3 — Add fixtures to subtests
+
+Fixtures work the same way as with regular split blocks. Declare them on
+the setup block (no `case:`); they are available in all case blocks:
+
+````{code-block} markdown
+<!-- name: test_file_cases; fixtures: tmp_path -->
+```python
+base = tmp_path / "data"
+base.mkdir()
+```
+
+<!-- name: test_file_cases; case: file_creation -->
+```python
+f = base / "a.txt"
+f.write_text("hello")
+assert f.exists()
+```
+
+<!-- name: test_file_cases; case: file_content -->
+```python
+f = base / "a.txt"
+f.write_text("hello")
+assert f.read_text() == "hello"
+```
+````
+
+`tmp_path` is requested once and shared across all cases. Each case
+receives its own fresh `tmp_path` value because pytest re-runs the
+function-scoped fixture for each subtest.
+
+## Step 4 — Prose between case blocks
+
+You can add explanatory text between `case:` blocks just like with regular
+split blocks:
+
+````{code-block} markdown
+<!-- name: test_counter -->
+```python
+from collections import Counter
+c = Counter()
+```
+
+Start by verifying the counter starts at zero:
+
+<!-- name: test_counter; case: initial_value -->
+```python
+assert c["missing_key"] == 0
+```
+
+Increment a key and check it:
+
+<!-- name: test_counter; case: after_increment -->
+```python
+c["x"] += 1
+assert c["x"] == 1
+```
+
+Multiple increments accumulate:
+
+<!-- name: test_counter; case: accumulation -->
+```python
+c["x"] += 1
+c["x"] += 1
+assert c["x"] == 2
+```
+````
+
+The prose between blocks is documentation — it is stripped during
+collection.
+
+## Step 5 — Case names in output
+
+Case names appear in the test output and in failure messages. Choose names
+that describe the scenario, not the implementation:
+
+```{admonition} Good case names
+:class: tip
+
+`case: empty_input`, `case: negative_number`, `case: unicode_string`,
+`case: max_value`
+```
+
+```{admonition} Unhelpful case names
+:class: warning
+
+`case: test1`, `case: case_a`, `case: foo`
+```
+
+Spaces are allowed in case names: `case: strips leading spaces` — they
+appear as-is in output.
+
+## How subtests work internally
+
+When the plugin collects a test with `case:` blocks, it wraps each case in
+a `with subtests.test(msg='...')` context manager. The `subtests` fixture
+is automatically added to the test's fixture list. If a case raises an
+exception, the context manager catches it, records the failure, and
+execution continues with the next case.
+
+## Common mistakes
+
+**Forgetting the setup block**
+
+If every block has a `case:`, there is no shared setup. Each case gets its
+own fresh namespace — variables defined in one case are not visible in
+others. Add one block without `case:` to define shared state.
+
+**Setup block also has `case:`**
+
+The block without `case:` is the setup. If you accidentally add `case:` to
+the setup block, it becomes a case and there is no shared setup.
+
+**Expecting a `subtests` import**
+
+You do not need to import anything. The `subtests` fixture is injected
+automatically by the plugin.
+
+## What you learned
+
+- Add `case: name` to mark a block as a subtest.
+- The block without `case:` is the shared setup.
+- All cases run even when one fails.
+- Fixtures are available in all case blocks.
+
+## Next steps
+
+{doc}`05_hidden_blocks` covers how to write documentation that looks
+polished to readers — with setup and assertions hidden in HTML comments —
+while still being fully tested.

--- a/docs/tutorial/05_hidden_blocks.md
+++ b/docs/tutorial/05_hidden_blocks.md
@@ -1,0 +1,256 @@
+# Tutorial 5 — Hidden code blocks
+
+The best documentation examples focus on one concept at a time. But tests
+need setup, teardown, and assertions that would clutter a documentation
+example. Hidden blocks solve this: you put the boilerplate inside an HTML
+comment so readers never see it, but the plugin runs it.
+
+## Prerequisites
+
+Completed {doc}`04_subtests`. You understand split blocks and fixtures.
+
+## The idea
+
+An HTML comment in Markdown hides its content from all renderers. If you
+put a Python code block inside the comment, readers do not see it — but
+markdown-pytest parses inside comments and runs the code.
+
+## Variant 1 — Hidden setup before a visible block
+
+The most common pattern: hidden imports and setup, visible demo code.
+
+In the raw Markdown source you write:
+
+````{code-block} text
+<!--
+name: test_csv_demo;
+fixtures: tmp_path
+```python
+import csv, io
+csv_file = tmp_path / "data.csv"
+csv_file.write_text("name,score\nAlice,95\nBob,87\n")
+```
+-->
+```python
+rows = []
+with open(csv_file) as f:
+    for row in csv.DictReader(f):
+        rows.append(row)
+```
+````
+
+What readers see when the Markdown is rendered:
+
+```{code-block} python
+rows = []
+with open(csv_file) as f:
+    for row in csv.DictReader(f):
+        rows.append(row)
+```
+
+Clean, focused, no boilerplate. But the test runs the hidden block first,
+so `csv_file` exists when the visible block runs.
+
+## Variant 2 — Hidden assertions after a visible block
+
+Use split blocks with a hidden second block to add assertions that readers
+do not need to see:
+
+````{code-block} text
+<!-- name: test_csv_demo -->
+```python
+rows = []
+with open(csv_file) as f:
+    for row in csv.DictReader(f):
+        rows.append(row)
+```
+<!--
+name: test_csv_demo
+```python
+assert len(rows) == 2
+assert rows[0] == {"name": "Alice", "score": "95"}
+```
+-->
+````
+
+Readers see only the `for` loop. The assertions are hidden but still run.
+
+## Step 1 — The complete polished pattern
+
+Combine both variants: hidden setup before, visible demo, hidden
+assertions after. This is the recommended pattern for tutorial-style
+documentation.
+
+In the raw Markdown:
+
+````{code-block} text
+<!--
+name: test_json_roundtrip;
+fixtures: tmp_path
+```python
+import json
+path = tmp_path / "config.json"
+```
+-->
+
+Write a config file:
+
+```python
+config = {"debug": True, "workers": 4}
+path.write_text(json.dumps(config))
+```
+
+Read it back:
+
+```python
+loaded = json.loads(path.read_text())
+assert loaded == config
+```
+<!--
+name: test_json_roundtrip
+```python
+assert loaded["debug"] is True
+assert loaded["workers"] == 4
+```
+-->
+````
+
+Readers see two code blocks — write and read — with prose between them.
+They look like a natural tutorial. The hidden blocks take care of imports,
+file setup, and final assertions.
+
+The blocks with the same name (`test_json_roundtrip`) are combined in
+document order:
+
+1. Hidden setup block (imports, `path`)
+2. Visible "write" block
+3. Visible "read" block
+4. Hidden assertion block
+
+## Step 2 — Try it yourself
+
+Create `guide.md` with this content (copy the raw text including the HTML
+comments — not the rendered version above):
+
+````{code-block} text
+## JSON round-trip
+
+<!--
+name: test_json_roundtrip;
+fixtures: tmp_path
+```python
+import json
+path = tmp_path / "config.json"
+```
+-->
+```python
+config = {"debug": True, "workers": 4}
+path.write_text(json.dumps(config))
+loaded = json.loads(path.read_text())
+```
+<!--
+name: test_json_roundtrip
+```python
+assert loaded == config
+```
+-->
+````
+
+Run:
+
+```{code-block} bash
+pytest guide.md -v
+```
+
+```{code-block} text
+guide.md::test_json_roundtrip PASSED
+```
+
+View the rendered result in any Markdown viewer — only the `config =...`
+block is visible.
+
+## Step 3 — Hidden block syntax rules
+
+The hidden block is a code block placed **inside** an HTML comment that
+also contains the `name:` metadata:
+
+```{code-block} text
+<!--
+name: test_foo
+```python
+# this code runs but is hidden from readers
+x = 1
+```
+-->
+```
+
+Note that the closing `-->` is on its own line **after** the closing
+` ``` `. The opening ` ```python ` and closing ` ``` ` are inside the
+comment.
+
+The comment can also carry other metadata. Put the metadata keys first,
+then the code fence:
+
+```{code-block} text
+<!--
+name: test_foo;
+fixtures: tmp_path
+```python
+p = tmp_path / "f.txt"
+```
+-->
+```
+
+## Step 4 — Multiple hidden blocks
+
+You can have more than one hidden block per test. They run in document
+order along with the visible blocks:
+
+````{code-block} text
+<!--
+name: test_multi_hidden;
+fixtures: tmp_path
+```python
+import json
+path = tmp_path / "x.json"
+```
+-->
+```python
+path.write_text(json.dumps({"a": 1}))
+```
+<!--
+name: test_multi_hidden
+```python
+assert json.loads(path.read_text()) == {"a": 1}
+```
+-->
+<!--
+name: test_multi_hidden
+```python
+assert path.exists()
+```
+-->
+````
+
+## Debugging hidden blocks
+
+Because hidden blocks are inside HTML comments, they do not show in
+rendered Markdown. If a test fails and you are not sure which hidden block
+is the problem, view the raw Markdown source and look for comments that
+contain code fences.
+
+The traceback always includes a line number pointing to the original
+Markdown file — you can jump straight to that line to find the relevant
+block.
+
+## What you learned
+
+- Place a code block inside an HTML comment to hide it from readers.
+- Hidden blocks run in document order with visible blocks.
+- The recommended pattern: hidden setup → visible demo → hidden assertions.
+- The hidden block's comment must contain the `name:` key and a code fence.
+
+## Next steps
+
+{doc}`06_async` shows how to test async code — functions that use
+`await` — with just an `async ` prefix on the test name.

--- a/docs/tutorial/06_async.md
+++ b/docs/tutorial/06_async.md
@@ -1,0 +1,222 @@
+# Tutorial 6 — Async tests
+
+If your library uses `asyncio` — coroutines, async context managers, async
+generators — your documentation examples will too. markdown-pytest supports
+top-level `await` in code blocks with a single prefix on the test name.
+
+## Prerequisites
+
+Completed {doc}`05_hidden_blocks`. Basic familiarity with Python's
+`asyncio` module.
+
+## Install the async extra
+
+Async tests require a pytest plugin that manages the event loop.
+`pytest-asyncio` is the most popular choice:
+
+```{code-block} bash
+pip install "markdown-pytest[async]"
+```
+
+This installs `pytest-asyncio`. You can use `aiomisc-pytest` or any other
+compatible plugin instead.
+
+Configure `pytest-asyncio` in `pyproject.toml`:
+
+```{code-block} toml
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+```
+
+Without `asyncio_mode = "auto"` you would need to mark every async test
+with `@pytest.mark.asyncio` — but since Markdown tests are not Python
+functions, the `auto` mode is required.
+
+## Step 1 — Write an async test
+
+Prefix the test name with `async ` (note the space):
+
+````{code-block} markdown
+<!-- name: async test_fetch -->
+```python
+import asyncio
+
+async def fetch_value():
+    await asyncio.sleep(0)   # simulate I/O
+    return 42
+
+result = await fetch_value()
+assert result == 42
+```
+````
+
+The `async ` prefix tells markdown-pytest to wrap the block in an
+`async def` function so that top-level `await` is valid. pytest-asyncio
+then runs it inside a managed event loop.
+
+Run:
+
+```{code-block} bash
+pytest guide.md::test_fetch -v
+```
+
+```{code-block} text
+guide.md::test_fetch PASSED
+```
+
+## Step 2 — Async with split blocks
+
+When a test is split across multiple blocks, only **one** of them needs
+the `async ` prefix — the whole test becomes async:
+
+````{code-block} markdown
+<!-- name: async test_pipeline -->
+```python
+import asyncio
+
+async def step1():
+    await asyncio.sleep(0)
+    return [1, 2, 3]
+```
+
+<!-- name: test_pipeline -->
+```python
+items = await step1()
+assert len(items) == 3
+```
+````
+
+The second block has no `async ` prefix but it still uses `await` because
+the overall test is async.
+
+## Step 3 — Async fixtures
+
+Async fixtures are supported. Define one in `conftest.py`:
+
+```{code-block} python
+# conftest.py
+import pytest
+
+@pytest.fixture
+async def db_connection():
+    # async setup
+    conn = await create_connection()
+    yield conn
+    # async teardown
+    await conn.close()
+```
+
+Request it in the usual way:
+
+````{code-block} markdown
+<!-- name: async test_db_query; fixtures: db_connection -->
+```python
+result = await db_connection.execute("SELECT 1")
+assert result == 1
+```
+````
+
+## Step 4 — Async with hidden blocks
+
+Hidden blocks work the same way in async tests. Use a hidden setup block
+to prepare async resources:
+
+````{code-block} text
+<!--
+name: async test_async_stream
+```python
+import asyncio
+
+async def make_stream(items):
+    for item in items:
+        await asyncio.sleep(0)
+        yield item
+```
+-->
+```python
+results = []
+async for value in make_stream([10, 20, 30]):
+    results.append(value)
+assert results == [10, 20, 30]
+```
+````
+
+## Step 5 — Async with subtests
+
+Async tests support `case:` blocks:
+
+````{code-block} markdown
+<!-- name: async test_async_cases -->
+```python
+import asyncio
+
+async def double(x):
+    await asyncio.sleep(0)
+    return x * 2
+```
+
+<!-- name: async test_async_cases; case: small_number -->
+```python
+assert await double(3) == 6
+```
+
+<!-- name: async test_async_cases; case: zero -->
+```python
+assert await double(0) == 0
+```
+
+<!-- name: async test_async_cases; case: large_number -->
+```python
+assert await double(1000) == 2000
+```
+````
+
+## Step 6 — Async subprocess mode
+
+Adding `subprocess: true` to an async test runs the code in a child
+process. The plugin automatically wraps the source in:
+
+```{code-block} python
+import asyncio
+
+async def __amain():
+    # your code here
+
+asyncio.run(__amain())
+```
+
+````{code-block} markdown
+<!-- name: async test_async_subprocess; subprocess: true -->
+```python
+import asyncio
+await asyncio.sleep(0)
+assert True
+```
+````
+
+Subprocess mode does not require pytest-asyncio in the child process —
+`asyncio.run()` manages the event loop directly.
+
+## What happens without an event loop plugin
+
+If you run an async test without pytest-asyncio (or a compatible plugin),
+you get a clear error message listing the available options:
+
+```{code-block} text
+FAILED guide.md::test_fetch - RuntimeError: No async pytest plugin found.
+Install one of: pytest-asyncio, aiomisc-pytest, anyio, ...
+```
+
+## What you learned
+
+- Prefix the test name with `async ` to enable top-level `await`.
+- Install `markdown-pytest[async]` for pytest-asyncio.
+- Set `asyncio_mode = "auto"` in `pyproject.toml`.
+- Only one block in a split test needs the `async ` prefix.
+- Hidden blocks, subtests, and subprocess mode all work with async.
+
+## Next steps
+
+{doc}`07_subprocess` covers subprocess isolation — running a test in a
+fresh Python process to test code that modifies global state or calls
+`sys.exit()`.

--- a/docs/tutorial/07_subprocess.md
+++ b/docs/tutorial/07_subprocess.md
@@ -1,0 +1,192 @@
+# Tutorial 7 — Subprocess mode
+
+Some code is hard to test safely in the same process as pytest:
+
+- Code that calls `sys.exit()` or `os._exit()` would terminate pytest.
+- Code that modifies `sys.modules`, `sys.path`, or other global state
+  leaks between tests.
+- Code that installs signal handlers or monkey-patches built-ins can
+  interfere with pytest's own machinery.
+
+Subprocess mode runs a test in a separate Python process so none of that
+can happen.
+
+## Prerequisites
+
+Completed {doc}`06_async`. No additional packages needed.
+
+## Step 1 — Add `subprocess: true`
+
+````{code-block} markdown
+<!-- name: test_isolated; subprocess: true -->
+```python
+import sys
+
+# Pollute sys.modules — this cannot affect the pytest process
+sys.modules["_fake_module_"] = object()
+assert "_fake_module_" in sys.modules
+```
+````
+
+Run:
+
+```{code-block} bash
+pytest guide.md::test_isolated -v
+```
+
+```{code-block} text
+guide.md::test_isolated PASSED
+```
+
+The `sys.modules` mutation exists only in the child process and disappears
+when it exits.
+
+## Step 2 — How subprocess mode executes your code
+
+When the plugin collects a subprocess test, it:
+
+1. Concatenates the source code from all blocks with the same name.
+2. Writes the source to a temporary `.py` file.
+3. Runs `python <tempfile>` as a child process.
+4. If the process exits with a non-zero code, the test fails and the
+   standard error output is shown as the failure message.
+
+The child process starts with a clean Python interpreter — no pytest, no
+fixtures, no loaded plugins.
+
+## Step 3 — Split blocks in subprocess mode
+
+Multiple blocks with the same name and `subprocess: true` are combined
+before being sent to the child process:
+
+````{code-block} markdown
+<!-- name: test_subprocess_split; subprocess: true -->
+```python
+def greet(name):
+    return f"Hello, {name}!"
+```
+
+<!-- name: test_subprocess_split; subprocess: true -->
+```python
+assert greet("world") == "Hello, world!"
+```
+````
+
+Both blocks must carry `subprocess: true`. The combined source runs in a
+single subprocess.
+
+## Step 4 — Hidden blocks with subprocess mode
+
+Hidden setup blocks work the same way — they are hidden from readers but
+included in the source sent to the child process:
+
+````{code-block} text
+<!--
+name: test_subprocess_hidden;
+subprocess: true
+```python
+EXPECTED = "success"
+```
+-->
+```python
+result = EXPECTED.upper()
+assert result == "SUCCESS"
+```
+````
+
+Readers see only the visible block. The hidden setup provides `EXPECTED`.
+
+## Step 5 — Async subprocess mode
+
+Prefix the name with `async ` to run async code in a subprocess. The
+plugin wraps the source in `asyncio.run()` automatically:
+
+````{code-block} markdown
+<!-- name: async test_async_subprocess; subprocess: true -->
+```python
+import asyncio
+
+async def work():
+    await asyncio.sleep(0)
+    return "done"
+
+result = await work()
+assert result == "done"
+```
+````
+
+No event loop plugin is needed in subprocess mode — `asyncio.run()`
+handles the event loop directly inside the child process.
+
+## Step 6 — Checking exit codes
+
+If the code under test calls `sys.exit(0)`, the test passes. Any non-zero
+exit code fails the test. This is how you test CLI tools that call
+`sys.exit()`:
+
+````{code-block} markdown
+<!-- name: test_exit_zero; subprocess: true -->
+```python
+import sys
+sys.exit(0)
+```
+````
+
+````{code-block} markdown
+<!-- name: test_bad_exit; mark: xfail(strict=True); subprocess: true -->
+```python
+import sys
+sys.exit(1)    # non-zero — test fails (and is expected to fail)
+```
+````
+
+## Limitations
+
+```{admonition} Fixtures are not available in subprocess mode
+:class: warning
+
+The child process does not run inside pytest, so `tmp_path`, `monkeypatch`,
+and other fixtures are not available. If your test needs fixtures, omit
+`subprocess: true`.
+```
+
+```{admonition} Subtests (case:) are not available in subprocess mode
+:class: warning
+
+`case:` blocks require the pytest `subtests` fixture, which is only
+available inside the pytest process. Use separate subprocess tests instead.
+```
+
+```{admonition} Import path
+:class: note
+
+The child process inherits the parent's `sys.path`. If your project is
+installed (or in the current directory), imports work normally. If you get
+`ModuleNotFoundError`, make sure the package is installed in the same
+environment.
+```
+
+## When to use subprocess mode
+
+| Scenario | Use subprocess? |
+|----------|----------------|
+| Code calls `sys.exit()` | Yes |
+| Code mutates `sys.modules` or `sys.path` | Yes |
+| Code installs signal handlers | Yes |
+| Normal function calls and assertions | No |
+| Code that needs fixtures | No |
+| Code that needs subtests | No |
+
+## What you learned
+
+- Add `subprocess: true` to run a block in a fresh Python process.
+- Split blocks work in subprocess mode — all blocks must carry the flag.
+- Hidden blocks are included in the subprocess source.
+- Async code works in subprocess mode via `asyncio.run()`.
+- Fixtures and subtests are not available in subprocess mode.
+
+## Next steps
+
+{doc}`08_doctest` covers the REPL / doctest mode — a way to write
+interactive-shell-style examples that check printed output, the way
+Python's own doctest module does.

--- a/docs/tutorial/08_doctest.md
+++ b/docs/tutorial/08_doctest.md
@@ -1,0 +1,211 @@
+# Tutorial 8 — REPL / doctest mode
+
+The Python interactive shell format (`>>>` prompts, expected output on the
+following lines) is widely recognised by developers. markdown-pytest can
+run blocks written in this format using Python's built-in `doctest` module.
+
+## Prerequisites
+
+Completed {doc}`07_subprocess`. No additional packages are needed for sync
+REPL tests.
+
+## Step 1 — Write a REPL block
+
+Add `repl: true` to the comment. Write the block as if you were typing
+into a Python shell:
+
+````{code-block} markdown
+<!-- name: test_greet; repl: true -->
+```python
+>>> def greet(name):
+...     return f"Hello, {name}!"
+>>> greet("world")
+'Hello, world!'
+>>> print(greet("pytest"))
+Hello, pytest!
+```
+````
+
+Rules:
+- Lines starting with `>>>` are executed.
+- Lines starting with `...` are continuation lines (inside blocks or
+  multi-line expressions).
+- Lines without a prompt that immediately follow `>>>` or `...` lines are
+  the **expected output**. The test fails if the actual output differs.
+- Blank lines between `>>>` statements are fine — they do not end the
+  block.
+
+Run:
+
+```{code-block} bash
+pytest guide.md::test_greet -v
+```
+
+```{code-block} text
+guide.md::test_greet PASSED
+```
+
+## Step 2 — Return values vs print output
+
+`repr()` of a return value is shown automatically (just like in a real
+shell). `print()` output appears as plain text without quotes.
+
+````{code-block} markdown
+<!-- name: test_output_types; repl: true -->
+```python
+>>> [1, 2, 3]
+[1, 2, 3]
+>>> print("hello")
+hello
+>>> 42
+42
+>>> x = 10
+>>> x
+10
+```
+````
+
+When a statement produces no return value (assignment, `import`, `for`
+loops), nothing is expected on the next line.
+
+## Step 3 — Standard doctest directives
+
+All `# doctest: +DIRECTIVE` flags work:
+
+````{code-block} markdown
+<!-- name: test_ellipsis; repl: true -->
+```python
+>>> [1, 2, 3, 4, 5]  # doctest: +ELLIPSIS
+[1, 2, ...]
+>>> "hello world"   # doctest: +NORMALIZE_WHITESPACE
+'hello  world'
+```
+````
+
+Useful directives:
+
+| Directive | What it does |
+|-----------|-------------|
+| `+ELLIPSIS` | `...` in expected output matches anything |
+| `+NORMALIZE_WHITESPACE` | Any run of whitespace matches any other |
+| `+SKIP` | Skip this specific example |
+| `+IGNORE_EXCEPTION_DETAIL` | Match exception type but not message |
+
+## Step 4 — Expecting exceptions
+
+Write the exception type and message as it would appear in the shell:
+
+````{code-block} markdown
+<!-- name: test_exception; repl: true -->
+```python
+>>> 1 / 0
+Traceback (most recent call last):
+    ...
+ZeroDivisionError: division by zero
+```
+````
+
+The `Traceback (most recent call last):` header and `...` on the next line
+are required by the doctest format. The module path in the exception
+message is optional — doctest matches only the last line by default.
+
+## Step 5 — Split REPL blocks
+
+Multiple blocks with the same name share a session — variables defined in
+an earlier block are available in later ones:
+
+````{code-block} markdown
+<!-- name: test_session; repl: true -->
+```python
+>>> items = [1, 2, 3]
+>>> len(items)
+3
+```
+
+Add an item and verify:
+
+<!-- name: test_session; repl: true -->
+```python
+>>> items.append(4)
+>>> items
+[1, 2, 3, 4]
+```
+````
+
+Both blocks carry `repl: true`. The session (namespace) is preserved
+across them — `items` is available in the second block.
+
+## Step 6 — Async REPL
+
+Prefix the name with `async ` to enable top-level `await` inside REPL
+blocks:
+
+````{code-block} markdown
+<!-- name: async test_async_repl; repl: true -->
+```python
+>>> import asyncio
+>>> async def fetch():
+...     await asyncio.sleep(0)
+...     return 42
+>>> await fetch()
+42
+```
+````
+
+Requires an async pytest plugin (same as regular async tests — see
+{doc}`06_async`).
+
+State is preserved across split async REPL blocks within the same event
+loop session.
+
+## When to use REPL mode vs regular mode
+
+| Situation | Use |
+|-----------|-----|
+| Checking printed output inline | `repl: true` |
+| Showing interactive exploration | `repl: true` |
+| Running a sequence of statements | regular |
+| Using fixtures | regular |
+| Using subtests | regular |
+
+REPL mode cannot use fixtures or `case:` subtests. If you need those
+features, use a regular block with explicit `assert` statements.
+
+## Common mistakes
+
+**Missing `...` continuation lines**
+
+Multi-line `>>>` statements require `...` on continuation lines:
+
+```{code-block} python
+>>> def f(x):
+...     return x + 1   # correct
+>>> def f(x):
+    return x + 1       # SyntaxError — missing ...
+```
+
+**Expected output on wrong line**
+
+The expected output must appear on the line **immediately** after the
+`>>>` or `...` block. A blank line ends the expected output and starts a
+new statement.
+
+**`repl: true` on only one block of a split pair**
+
+All blocks in a split REPL test must carry `repl: true`. If one block
+lacks it, that block is treated as a regular test block instead of a
+doctest block.
+
+## What you learned
+
+- Add `repl: true` to run a block as a Python interactive-shell session.
+- `>>>` lines are code; following lines without a prompt are expected
+  output.
+- All standard `# doctest: +DIRECTIVE` flags are supported.
+- Split REPL blocks share a session across the same name.
+- Prefix the name with `async ` for top-level `await` in REPL blocks.
+
+---
+
+You have now completed all eight tutorials. For task-specific guidance,
+move on to the **How-to guides**.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,12 @@ dev = [
     "pytest-asyncio>=1,<2",
     "ruff",
 ]
+docs = [
+    "furo",
+    "myst-parser",
+    "sphinx",
+    "sphinx-copybutton",
+]
 
 [build-system]
 requires = ["hatchling"]
@@ -59,7 +65,7 @@ markdown-pytest = "markdown_pytest"
 [project.urls]
 "Source" = "https://github.com/mosquito/markdown-pytest"
 "Tracker" = "https://github.com/mosquito/markdown-pytest/issues"
-"Documentation" = "https://github.com/mosquito/markdown-pytest/blob/master/README.md"
+"Documentation" = "https://mosquito.github.io/markdown-pytest/"
 
 [tool.ruff]
 line-length = 80

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,30 @@ revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version < '3.15'",
+    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
+
+[[package]]
+name = "accessible-pygments"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c1/bbac6a50d02774f91572938964c582fff4270eee73ab822a4aeea4d8b11b/accessible_pygments-0.0.5.tar.gz", hash = "sha256:40918d3e6a2b619ad424cb91e556bd3bd8865443d9f22f1dcdf79e33c8046872", size = 1377899, upload-time = "2024-05-10T11:23:10.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/3f/95338030883d8c8b91223b4e21744b04d11b161a3ef117295d8241f50ab4/accessible_pygments-0.0.5-py3-none-any.whl", hash = "sha256:88ae3211e68a1d0b011504b2ffc1691feafce124b845bd072ab6f9f66f34d4b7", size = 1395903, upload-time = "2024-05-10T11:23:08.421Z" },
+]
+
+[[package]]
+name = "alabaster"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/f8/d9c74d0daf3f742840fd818d69cfae176fa332022fd44e3469487d5a9420/alabaster-1.0.0.tar.gz", hash = "sha256:c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e", size = 24210, upload-time = "2024-07-26T18:15:03.762Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl", hash = "sha256:fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b", size = 13929, upload-time = "2024-07-26T18:15:02.05Z" },
 ]
 
 [[package]]
@@ -47,6 +70,15 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
 name = "backports-asyncio-runner"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -56,12 +88,165 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/08/0f303cb0b529e456bb116f2d50565a482694fbb94340bf56d44677e7ed03/charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d", size = 315182, upload-time = "2026-04-02T09:25:40.673Z" },
+    { url = "https://files.pythonhosted.org/packages/24/47/b192933e94b546f1b1fe4df9cc1f84fcdbf2359f8d1081d46dd029b50207/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8", size = 209329, upload-time = "2026-04-02T09:25:42.354Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b4/01fa81c5ca6141024d89a8fc15968002b71da7f825dd14113207113fabbd/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:511ef87c8aec0783e08ac18565a16d435372bc1ac25a91e6ac7f5ef2b0bff790", size = 231230, upload-time = "2026-04-02T09:25:44.281Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f7/7b991776844dfa058017e600e6e55ff01984a063290ca5622c0b63162f68/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc", size = 225890, upload-time = "2026-04-02T09:25:45.475Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e7/bed0024a0f4ab0c8a9c64d4445f39b30c99bd1acd228291959e3de664247/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393", size = 216930, upload-time = "2026-04-02T09:25:46.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ab/b18f0ab31cdd7b3ddb8bb76c4a414aeb8160c9810fdf1bc62f269a539d87/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:12d8baf840cc7889b37c7c770f478adea7adce3dcb3944d02ec87508e2dcf153", size = 202109, upload-time = "2026-04-02T09:25:48.031Z" },
+    { url = "https://files.pythonhosted.org/packages/82/e5/7e9440768a06dfb3075936490cb82dbf0ee20a133bf0dd8551fa096914ec/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d560742f3c0d62afaccf9f41fe485ed69bd7661a241f86a3ef0f0fb8b1a397af", size = 214684, upload-time = "2026-04-02T09:25:49.245Z" },
+    { url = "https://files.pythonhosted.org/packages/71/94/8c61d8da9f062fdf457c80acfa25060ec22bf1d34bbeaca4350f13bcfd07/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b14b2d9dac08e28bb8046a1a0434b1750eb221c8f5b87a68f4fa11a6f97b5e34", size = 212785, upload-time = "2026-04-02T09:25:50.671Z" },
+    { url = "https://files.pythonhosted.org/packages/66/cd/6e9889c648e72c0ab2e5967528bb83508f354d706637bc7097190c874e13/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:bc17a677b21b3502a21f66a8cc64f5bfad4df8a0b8434d661666f8ce90ac3af1", size = 203055, upload-time = "2026-04-02T09:25:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/92/2e/7a951d6a08aefb7eb8e1b54cdfb580b1365afdd9dd484dc4bee9e5d8f258/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:750e02e074872a3fad7f233b47734166440af3cdea0add3e95163110816d6752", size = 232502, upload-time = "2026-04-02T09:25:53.388Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d5/abcf2d83bf8e0a1286df55cd0dc1d49af0da4282aa77e986df343e7de124/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:4e5163c14bffd570ef2affbfdd77bba66383890797df43dc8b4cc7d6f500bf53", size = 214295, upload-time = "2026-04-02T09:25:54.765Z" },
+    { url = "https://files.pythonhosted.org/packages/47/3a/7d4cd7ed54be99973a0dc176032cba5cb1f258082c31fa6df35cff46acfc/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6ed74185b2db44f41ef35fd1617c5888e59792da9bbc9190d6c7300617182616", size = 227145, upload-time = "2026-04-02T09:25:55.904Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/98/3a45bf8247889cf28262ebd3d0872edff11565b2a1e3064ccb132db3fbb0/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:94e1885b270625a9a828c9793b4d52a64445299baa1fea5a173bf1d3dd9a1a5a", size = 218884, upload-time = "2026-04-02T09:25:57.074Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/2e8b7f8915ed5c9ef13aa828d82738e33888c485b65ebf744d615040c7ea/charset_normalizer-3.4.7-cp310-cp310-win32.whl", hash = "sha256:6785f414ae0f3c733c437e0f3929197934f526d19dfaa75e18fdb4f94c6fb374", size = 148343, upload-time = "2026-04-02T09:25:58.199Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1b/3b8c8c77184af465ee9ad88b5aea46ea6b2e1f7b9dc9502891e37af21e30/charset_normalizer-3.4.7-cp310-cp310-win_amd64.whl", hash = "sha256:6696b7688f54f5af4462118f0bfa7c1621eeb87154f77fa04b9295ce7a8f2943", size = 159174, upload-time = "2026-04-02T09:25:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/feb40dca40dbb21e0a908801782d9288c64fc8d8e562c2098e9994c8c21b/charset_normalizer-3.4.7-cp310-cp310-win_arm64.whl", hash = "sha256:66671f93accb62ed07da56613636f3641f1a12c13046ce91ffc923721f23c008", size = 147805, upload-time = "2026-04-02T09:26:00.756Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.21.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f", size = 2204444, upload-time = "2024-04-23T18:57:18.24Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2", size = 587408, upload-time = "2024-04-23T18:57:14.835Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.22.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version == '3.11.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
 ]
 
 [[package]]
@@ -77,12 +262,60 @@ wheels = [
 ]
 
 [[package]]
+name = "furo"
+version = "2025.12.19"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "accessible-pygments" },
+    { name = "beautifulsoup4" },
+    { name = "pygments" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx-basic-ng" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/20/5f5ad4da6a5a27c80f2ed2ee9aee3f9e36c66e56e21c00fde467b2f8f88f/furo-2025.12.19.tar.gz", hash = "sha256:188d1f942037d8b37cd3985b955839fea62baa1730087dc29d157677c857e2a7", size = 1661473, upload-time = "2025-12-19T17:34:40.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/b2/50e9b292b5cac13e9e81272c7171301abc753a60460d21505b606e15cf21/furo-2025.12.19-py3-none-any.whl", hash = "sha256:bb0ead5309f9500130665a26bee87693c41ce4dbdff864dbfb6b0dae4673d24f", size = 339262, upload-time = "2025-12-19T17:34:38.905Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "imagesize"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/e6/7bf14eeb8f8b7251141944835abd42eb20a658d89084b7e1f3e5fe394090/imagesize-2.0.0.tar.gz", hash = "sha256:8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3", size = 1773045, upload-time = "2026-03-03T14:18:29.941Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl", hash = "sha256:5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96", size = 9441, upload-time = "2026-03-03T14:18:27.892Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]
@@ -171,6 +404,38 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "mdurl", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "mdurl", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
 name = "markdown-pytest"
 version = "0.3.2"
 source = { editable = "." }
@@ -187,6 +452,15 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
+docs = [
+    { name = "furo" },
+    { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "myst-parser", version = "5.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx-copybutton" },
+]
 
 [package.metadata]
 requires-dist = [{ name = "pytest-asyncio", marker = "extra == 'async'", specifier = ">=1,<2" }]
@@ -198,6 +472,119 @@ dev = [
     { name = "pytest", specifier = ">=9.0" },
     { name = "pytest-asyncio", specifier = ">=1,<2" },
     { name = "ruff" },
+]
+docs = [
+    { name = "furo" },
+    { name = "myst-parser" },
+    { name = "sphinx" },
+    { name = "sphinx-copybutton" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
+    { url = "https://files.pythonhosted.org/packages/98/1b/fbd8eed11021cabd9226c37342fa6ca4e8a98d8188a8d9b66740494960e4/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419", size = 12057, upload-time = "2025-09-27T18:36:07.165Z" },
+    { url = "https://files.pythonhosted.org/packages/40/01/e560d658dc0bb8ab762670ece35281dec7b6c1b33f5fbc09ebb57a185519/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695", size = 22050, upload-time = "2025-09-27T18:36:08.005Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591", size = 20681, upload-time = "2025-09-27T18:36:08.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2a/b5c12c809f1c3045c4d580b035a743d12fcde53cf685dbc44660826308da/markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c", size = 20705, upload-time = "2025-09-27T18:36:10.131Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e3/9427a68c82728d0a88c50f890d0fc072a1484de2f3ac1ad0bfc1a7214fd5/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f", size = 21524, upload-time = "2025-09-27T18:36:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/23578f29e9e582a4d0278e009b38081dbe363c5e7165113fad546918a232/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6", size = 20282, upload-time = "2025-09-27T18:36:12.573Z" },
+    { url = "https://files.pythonhosted.org/packages/56/21/dca11354e756ebd03e036bd8ad58d6d7168c80ce1fe5e75218e4945cbab7/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1", size = 20745, upload-time = "2025-09-27T18:36:13.504Z" },
+    { url = "https://files.pythonhosted.org/packages/87/99/faba9369a7ad6e4d10b6a5fbf71fa2a188fe4a593b15f0963b73859a1bbd/markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa", size = 14571, upload-time = "2025-09-27T18:36:14.779Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/25/55dc3ab959917602c96985cb1253efaa4ff42f71194bddeb61eb7278b8be/markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8", size = 15056, upload-time = "2025-09-27T18:36:16.125Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9e/0a02226640c255d1da0b8d12e24ac2aa6734da68bff14c05dd53b94a0fc3/markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1", size = 13932, upload-time = "2025-09-27T18:36:17.311Z" },
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "markdown-it-py", version = "4.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -269,6 +656,49 @@ wheels = [
 ]
 
 [[package]]
+name = "myst-parser"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "jinja2", marker = "python_full_version < '3.11'" },
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "mdit-py-plugins", marker = "python_full_version < '3.11'" },
+    { name = "pyyaml", marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/a5/9626ba4f73555b3735ad86247a8077d4603aa8628537687c839ab08bfe44/myst_parser-4.0.1.tar.gz", hash = "sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4", size = 93985, upload-time = "2025-02-12T10:53:03.833Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/df/76d0321c3797b54b60fef9ec3bd6f4cfd124b9e422182156a1dd418722cf/myst_parser-4.0.1-py3-none-any.whl", hash = "sha256:9134e88959ec3b5780aedf8a99680ea242869d012e8821db3126d427edc9c95d", size = 84579, upload-time = "2025-02-12T10:53:02.078Z" },
+]
+
+[[package]]
+name = "myst-parser"
+version = "5.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "jinja2", marker = "python_full_version >= '3.11'" },
+    { name = "markdown-it-py", version = "4.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "mdit-py-plugins", marker = "python_full_version >= '3.11'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/dc/603751677fff302f34396e206b610f556a59d7fe58b9a2145f54e96b48e8/myst_parser-5.1.0.tar.gz", hash = "sha256:ab69322dc6719dcc7f296479dbb70181b66df6ed315064f92dbc85c0e1bf2f02", size = 101182, upload-time = "2026-05-13T09:38:19.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/dc/f3dfb7488b770f3f67e6545085bf2abea5172e88f57b8ad25ef860ca704c/myst_parser-5.1.0-py3-none-any.whl", hash = "sha256:9c91c52b3cdb4d94a6506e4fab4e2f296c7623a0da0dcbe6de1565c3dad67a8a", size = 85817, upload-time = "2026-05-13T09:38:17.904Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -337,6 +767,94 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
+    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "roman-numerals"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/f9/41dc953bbeb056c17d5f7a519f50fdf010bd0553be2d630bc69d1e022703/roman_numerals-4.1.0.tar.gz", hash = "sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2", size = 9077, upload-time = "2025-12-17T18:25:34.381Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl", hash = "sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7", size = 7676, upload-time = "2025-12-17T18:25:33.098Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.16"
 source = { registry = "https://pypi.org/simple" }
@@ -359,6 +877,200 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/74/0d/f2cd247ad32633a5c36e97141a2c21b11c6279f7957bc2ff360b1e08fddd/ruff-0.15.16-py3-none-win32.whl", hash = "sha256:580378f7bd4aa25f72e74aa54948a9622f142b1e509521dd10902e886681cc1e", size = 10735541, upload-time = "2026-06-04T16:32:30.145Z" },
     { url = "https://files.pythonhosted.org/packages/8b/9e/02e845ef151b1dee585e55c4739f8e1734ae1d9f1221dff65761c162208b/ruff-0.15.16-py3-none-win_amd64.whl", hash = "sha256:408256017284eddf98fff77b29aa4fb30f586042d535b2d9befc6512f400aaec", size = 11843403, upload-time = "2026-06-04T16:32:39.76Z" },
     { url = "https://files.pythonhosted.org/packages/15/19/016553f86f207450aebebc2b2b5088d086b901cc8186c02ac4284db3bd88/ruff-0.15.16-py3-none-win_arm64.whl", hash = "sha256:8cd61783afb39638a7133ef0d2dfb1e91277593962f81b5a8423eb0b888a6121", size = 11134555, upload-time = "2026-06-04T16:33:00.136Z" },
+]
+
+[[package]]
+name = "snowballstemmer"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/f8/0a71edf031f03c40db17503cb8ca78a69a171254e568e7db241b0ab57ea1/snowballstemmer-3.1.1.tar.gz", hash = "sha256:e07bbc54a0d798fe6010a12398422e62a8bfbba95c394fd0956ef58cb4d3e260", size = 123314, upload-time = "2026-06-03T00:56:40.194Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/07/2ebca9b11fb9be7340a818d8d6f63feaebb146be2c4afbd6061701d6df6e/snowballstemmer-3.1.1-py3-none-any.whl", hash = "sha256:7e207fa178741da09cdee59d3ecec3827ad5f92b1fc5c9ff3755b639f71f5752", size = 104164, upload-time = "2026-06-03T00:56:38.614Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
+]
+
+[[package]]
+name = "sphinx"
+version = "8.1.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "alabaster", marker = "python_full_version < '3.11'" },
+    { name = "babel", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "imagesize", marker = "python_full_version < '3.11'" },
+    { name = "jinja2", marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "requests", marker = "python_full_version < '3.11'" },
+    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/60/1ddff83a56d33aaf6f10ec8ce84b4c007d9368b21008876fceda7e7381ef/sphinx-8.1.3-py3-none-any.whl", hash = "sha256:09719015511837b76bf6e03e42eb7595ac8c2e41eeb9c29c5b755c6b677992a2", size = 3487125, upload-time = "2024-10-13T20:27:10.448Z" },
+]
+
+[[package]]
+name = "sphinx"
+version = "9.0.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "alabaster", marker = "python_full_version == '3.11.*'" },
+    { name = "babel", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "imagesize", marker = "python_full_version == '3.11.*'" },
+    { name = "jinja2", marker = "python_full_version == '3.11.*'" },
+    { name = "packaging", marker = "python_full_version == '3.11.*'" },
+    { name = "pygments", marker = "python_full_version == '3.11.*'" },
+    { name = "requests", marker = "python_full_version == '3.11.*'" },
+    { name = "roman-numerals", marker = "python_full_version == '3.11.*'" },
+    { name = "snowballstemmer", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version == '3.11.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/3f/4bbd76424c393caead2e1eb89777f575dee5c8653e2d4b6afd7a564f5974/sphinx-9.0.4-py3-none-any.whl", hash = "sha256:5bebc595a5e943ea248b99c13814c1c5e10b3ece718976824ffa7959ff95fffb", size = 3917713, upload-time = "2025-12-04T07:45:24.944Z" },
+]
+
+[[package]]
+name = "sphinx"
+version = "9.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version >= '3.12' and python_full_version < '3.15'",
+]
+dependencies = [
+    { name = "alabaster", marker = "python_full_version >= '3.12'" },
+    { name = "babel", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "imagesize", marker = "python_full_version >= '3.12'" },
+    { name = "jinja2", marker = "python_full_version >= '3.12'" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
+    { name = "pygments", marker = "python_full_version >= '3.12'" },
+    { name = "requests", marker = "python_full_version >= '3.12'" },
+    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
+    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/f7/b1884cb3188ab181fc81fa00c266699dab600f927a964df02ec3d5d1916a/sphinx-9.1.0-py3-none-any.whl", hash = "sha256:c84fdd4e782504495fe4f2c0b3413d6c2bf388589bb352d439b2a3bb99991978", size = 3921742, upload-time = "2025-12-31T15:09:25.561Z" },
+]
+
+[[package]]
+name = "sphinx-basic-ng"
+version = "1.0.0b2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/0b/a866924ded68efec7a1759587a4e478aec7559d8165fac8b2ad1c0e774d6/sphinx_basic_ng-1.0.0b2.tar.gz", hash = "sha256:9ec55a47c90c8c002b5960c57492ec3021f5193cb26cebc2dc4ea226848651c9", size = 20736, upload-time = "2023-07-08T18:40:54.166Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/dd/018ce05c532a22007ac58d4f45232514cd9d6dd0ee1dc374e309db830983/sphinx_basic_ng-1.0.0b2-py3-none-any.whl", hash = "sha256:eb09aedbabfb650607e9b4b68c9d240b90b1e1be221d6ad71d61c52e29f7932b", size = 22496, upload-time = "2023-07-08T18:40:52.659Z" },
+]
+
+[[package]]
+name = "sphinx-copybutton"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/2b/a964715e7f5295f77509e59309959f4125122d648f86b4fe7d70ca1d882c/sphinx-copybutton-0.5.2.tar.gz", hash = "sha256:4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd", size = 23039, upload-time = "2023-04-14T08:10:22.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/48/1ea60e74949eecb12cdd6ac43987f9fd331156388dcc2319b45e2ebb81bf/sphinx_copybutton-0.5.2-py3-none-any.whl", hash = "sha256:fb543fd386d917746c9a2c50360c7905b605726b9355cd26e9974857afeae06e", size = 13343, upload-time = "2023-04-14T08:10:20.844Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-applehelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/6e/b837e84a1a704953c62ef8776d45c3e8d759876b4a84fe14eba2859106fe/sphinxcontrib_applehelp-2.0.0.tar.gz", hash = "sha256:2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1", size = 20053, upload-time = "2024-07-29T01:09:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl", hash = "sha256:4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5", size = 119300, upload-time = "2024-07-29T01:08:58.99Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-devhelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/d2/5beee64d3e4e747f316bae86b55943f51e82bb86ecd325883ef65741e7da/sphinxcontrib_devhelp-2.0.0.tar.gz", hash = "sha256:411f5d96d445d1d73bb5d52133377b4248ec79db5c793ce7dbe59e074b4dd1ad", size = 12967, upload-time = "2024-07-29T01:09:23.417Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl", hash = "sha256:aefb8b83854e4b0998877524d1029fd3e6879210422ee3780459e28a1f03a8a2", size = 82530, upload-time = "2024-07-29T01:09:21.945Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-htmlhelp"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/93/983afd9aa001e5201eab16b5a444ed5b9b0a7a010541e0ddfbbfd0b2470c/sphinxcontrib_htmlhelp-2.1.0.tar.gz", hash = "sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9", size = 22617, upload-time = "2024-07-29T01:09:37.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl", hash = "sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8", size = 98705, upload-time = "2024-07-29T01:09:36.407Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-jsmath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8", size = 5787, upload-time = "2019-01-21T16:10:16.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178", size = 5071, upload-time = "2019-01-21T16:10:14.333Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-qthelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/bc/9104308fc285eb3e0b31b67688235db556cd5b0ef31d96f30e45f2e51cae/sphinxcontrib_qthelp-2.0.0.tar.gz", hash = "sha256:4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab", size = 17165, upload-time = "2024-07-29T01:09:56.435Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl", hash = "sha256:b18a828cdba941ccd6ee8445dbe72ffa3ef8cbe7505d8cd1fa0d42d3f2d5f3eb", size = 88743, upload-time = "2024-07-29T01:09:54.885Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-serializinghtml"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
 ]
 
 [[package]]
@@ -422,4 +1134,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]


### PR DESCRIPTION
## Summary

- 17 pages of documentation structured by the [Diátaxis](https://diataxis.fr) framework
- **8 step-by-step tutorials**: first test → split blocks → fixtures → subtests → hidden blocks → async → subprocess → doctest/REPL
- **4 how-to guides**: marks, conftest.py, CI/CD integration, mixing languages
- **3 reference pages**: comment syntax, configuration, supported environments
- **1 explanation page**: how the plugin works internally

## Stack

- Sphinx + [Furo](https://pradyunsg.me/furo/) theme
- [MyST Parser](https://myst-parser.readthedocs.io/) (Markdown in Sphinx)
- `sphinx-copybutton` (copy buttons on all code blocks)
- `docs` dependency group in `pyproject.toml`

## Deploy

`.github/workflows/docs.yml` builds and publishes to GitHub Pages on every push to `master`.

To activate: Settings → Pages → Source: **GitHub Actions**.

## Build locally

```bash
uv run --group docs sphinx-build -b html docs docs/_build/html
```