### PR TITLE
fix: support pytest>=9.1 by switching to file_path hookspec

### DIFF
--- a/markdown_pytest.py
+++ b/markdown_pytest.py
@@ -532,7 +532,7 @@ class MDModule(pytest.Module):
         test_prefix = self.config.getoption("--md-prefix")
 
         blocks_by_name: Dict[str, list] = {}
-        for block in parse_code_blocks(str(self.fspath)):
+        for block in parse_code_blocks(str(self.path)):
             if not block.name.startswith(test_prefix):
                 continue
             blocks_by_name.setdefault(block.name, []).append(block)
@@ -613,9 +613,9 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 @pytest.hookimpl(trylast=True)
 def pytest_collect_file(
-    path: Any,
+    file_path: Path,
     parent: pytest.Collector,
 ) -> Optional[MDModule]:
-    if path.ext.lower() not in (".md", ".markdown"):
+    if file_path.suffix.lower() not in (".md", ".markdown"):
         return None
-    return MDModule.from_parent(parent=parent, path=Path(path))
+    return MDModule.from_parent(parent=parent, path=file_path)


### PR DESCRIPTION
## Summary
- pytest 9.1 dropped the legacy `path` (py.path / `LEGACY_PATH`) parameter from the `pytest_collect_file` hookspec, leaving only `file_path: Path`. Our hookimpl declared `path`, so pluggy refused to load the plugin on 9.1 with `PluginValidationError`.
- Switch the hookimpl to `file_path: Path` and use pathlib semantics (`suffix` instead of py.path's `ext`).
- Replace `self.fspath` with `self.path` on `MDModule` for the same reason (`fspath` is gone on `pytest.Module` in 9.1).

The new signature is backward compatible — both `file_path` and `parent` exist in the 9.0 hookspec too.

## Test plan
- [x] `pytest>=9.0,<9.1` — 150 passed, 1 skipped, 11 xfailed
- [x] `pytest>=9.1` — 150 passed, 1 skipped, 11 xfailed